### PR TITLE
Fix Blog Width

### DIFF
--- a/version_control/Codurance_September2020/css/_blog.css
+++ b/version_control/Codurance_September2020/css/_blog.css
@@ -781,14 +781,11 @@ section.container.blog  .custom-col-lg-9.custom-overflow-y-hidden .row {
   display: block;
   transition: all .3s ease-in-out;
 }
-
-section.container.blog .custom-col-lg-9.custom-overflow-y-hidden {
-  -ms-flex: 0 0 100%;
-  flex: 0 0 100%;
-  max-width: 100%;
-  padding:0;
+@media (min-width: 768px) {
+  section.container.blog .custom-col-lg-9.custom-overflow-y-hidden {
+    padding:0;
+  }
 }
-
 
 .text-right {
   text-align: right!important;
@@ -826,7 +823,7 @@ a.u-icon-v2 {
     overflow: hidden;
     z-index: 2;
 }
-.blog .blog-img { 
+.blog .blog-img {
   margin: 20px 0;
 }
 


### PR DESCRIPTION
This PR fixed the [following issue](https://codurance-online.leankit.com/card/1393844265).

There were overwriting styles incorrectly setting the blog content's width. I have removed this styles. 

I've wrapped the remaining style within a media query that follows our small breakpoint within our design system, to enable some padding on the sides on mobile devices. 

This provides a better reading experience on these devices but pulling in text from touching the edges of the screens. 