### PR TITLE
Fit Video on Softmod Page

### DIFF
--- a/version_control/Codurance_September2020/css/_website.css
+++ b/version_control/Codurance_September2020/css/_website.css
@@ -103,19 +103,6 @@ img{
   max-width: 1800px;
   margin: 0px auto;
 }
-.hs-services-inner-section1 .dnd-section .embed-video {
-  margin-bottom: 100px;
-}
-@media (min-width: 1024) {
-  .hs-services-inner-section1 .dnd-section .embed-video {
-    margin-top: 140px;
-  }
-}
-@media (max-width: 1023) {
-  .hs-services-inner-section1 .dnd-section .embed-video {
-    margin-top: 100px;
-  }
-}
 
 .hs-training-inner-section1 .dnd-section {
   background-color: #efefef;

--- a/version_control/Codurance_September2020/css/_website.css
+++ b/version_control/Codurance_September2020/css/_website.css
@@ -104,9 +104,19 @@ img{
   margin: 0px auto;
 }
 .hs-services-inner-section1 .dnd-section .embed-video {
-  margin-top: 100px;
   margin-bottom: 100px;
 }
+@media (min-width: 1024) {
+  .hs-services-inner-section1 .dnd-section .embed-video {
+    margin-top: 140px;
+  }
+}
+@media (max-width: 1023) {
+  .hs-services-inner-section1 .dnd-section .embed-video {
+    margin-top: 100px;
+  }
+}
+
 .hs-training-inner-section1 .dnd-section {
   background-color: #efefef;
   padding-top: 100px;

--- a/version_control/Codurance_September2020/css/temp-softmod-page-overrides.css
+++ b/version_control/Codurance_September2020/css/temp-softmod-page-overrides.css
@@ -13,5 +13,24 @@
 }
 
 .cm-tabber-section {
+  background-image: none !important;
+  background-color: #2b3342;
   padding-top: 100px;
+}
+@media (max-width: 1299px) and (min-width: 768px) {
+  .cm-tabber-section {
+    padding-bottom: 10px;
+  }
+}
+
+.cm-tabber-section__intro,
+.cm-tabber-section__intro > h2,
+.cm-tabber__large-screen-controls > .tabmenu  {
+  color: white;
+}
+@media (max-width: 1023px) {
+  .cm-tabber__panel::before,
+  .cm-tabber__panel:not(.active)::before {
+    color: white;
+  }
 }

--- a/version_control/Codurance_September2020/css/temp-softmod-page-overrides.css
+++ b/version_control/Codurance_September2020/css/temp-softmod-page-overrides.css
@@ -1,0 +1,17 @@
+.embed-video {
+  margin-bottom: 100px;
+}
+@media (min-width: 1024px) {
+.embed-video {
+    margin-top: 140px;
+  }
+}
+@media (max-width: 1023px) {
+.embed-video {
+    margin-top: 100px;
+  }
+}
+
+.cm-tabber-section {
+  padding-top: 100px;
+}


### PR DESCRIPTION
This PR introduces some temporary style updates that can be applied to only the Software Modernisation page. This is because otherwise, to enable the video to be on the page, components like the tabber will have to be amended which would affect the other service line pages that contain it. 