### PR TITLE
Add Page Header Slice Module to Events Page

### DIFF
--- a/version_control/Codurance_September2020/css/event-page.css
+++ b/version_control/Codurance_September2020/css/event-page.css
@@ -1,6 +1,12 @@
 {% set overlap = 200 %}
 {% set ultimate_max_width = 1800 %}
 
+.events-header-slice {
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 50px;
+}
+
 main {
   margin-bottom: 100px;
 }

--- a/version_control/Codurance_September2020/modules/Header Slice.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/fields.json
@@ -1,0 +1,89 @@
+[ {
+  "id" : "e0e5d286-8af5-93d6-dd22-87ae71925619",
+  "name" : "heading",
+  "label" : "Heading",
+  "required" : false,
+  "locked" : false,
+  "validation_regex" : "",
+  "placeholder" : "Heading Text Here",
+  "allow_new_line" : false,
+  "show_emoji_picker" : false,
+  "type" : "text"
+}, {
+  "id" : "d1e62581-05bb-9ca5-579e-87b0e5c0c913",
+  "name" : "body_text",
+  "label" : "Body Text",
+  "required" : false,
+  "locked" : false,
+  "validation_regex" : "",
+  "placeholder" : "Body Text Here",
+  "allow_new_line" : false,
+  "show_emoji_picker" : false,
+  "type" : "text"
+}, {
+  "id" : "b1b2cd48-eca5-b544-9ea1-121016502acb",
+  "name" : "image",
+  "label" : "Image",
+  "required" : false,
+  "locked" : false,
+  "children" : [ {
+    "id" : "01aec4b1-3553-0f49-2689-43c0ecb6281a",
+    "name" : "image_type",
+    "label" : "Image Type",
+    "required" : false,
+    "locked" : false,
+    "display" : "select",
+    "choices" : [ [ "linked_image", "Linked Image" ], [ "svg_code", "SVG Code" ] ],
+    "type" : "choice",
+    "default" : "svg_code"
+  }, {
+    "id" : "cd5ff6a3-17f7-6cf6-a7d8-44cf743256a1",
+    "name" : "linked_image",
+    "label" : "Linked Image",
+    "required" : false,
+    "locked" : false,
+    "visibility" : {
+      "controlling_field" : "01aec4b1-3553-0f49-2689-43c0ecb6281a",
+      "controlling_value_regex" : "linked_image",
+      "operator" : "EQUAL",
+      "access" : null,
+      "hidden_subfields" : null
+    },
+    "responsive" : true,
+    "resizable" : false,
+    "show_loading" : false,
+    "type" : "image",
+    "default" : {
+      "size_type" : "auto",
+      "src" : "",
+      "alt" : null,
+      "loading" : "disabled"
+    }
+  }, {
+    "id" : "4607f3e4-2145-17ba-36d2-563ba0acb403",
+    "name" : "svg_code",
+    "label" : "SVG Code",
+    "required" : false,
+    "locked" : false,
+    "visibility" : {
+      "controlling_field" : "01aec4b1-3553-0f49-2689-43c0ecb6281a",
+      "controlling_value_regex" : "svg_code",
+      "operator" : "EQUAL",
+      "access" : null,
+      "hidden_subfields" : null
+    },
+    "type" : "richtext"
+  } ],
+  "tab" : "CONTENT",
+  "expanded" : false,
+  "type" : "group",
+  "default" : {
+    "image_type" : "svg_code",
+    "linked_image" : {
+      "size_type" : "auto",
+      "src" : "",
+      "alt" : null,
+      "loading" : "disabled"
+    }
+  }
+} ]

--- a/version_control/Codurance_September2020/modules/Header Slice.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/fields.json
@@ -73,6 +73,16 @@
       "hidden_subfields" : null
     },
     "type" : "richtext"
+  }, {
+    "id" : "9db088a4-2d09-b89f-ae59-fb2849249034",
+    "name" : "alignment",
+    "label" : "Alignment",
+    "required" : false,
+    "locked" : false,
+    "display" : "select",
+    "choices" : [ [ "flex-start", "Top" ], [ "center", "Centre" ], [ "flex-end", "Bottom" ] ],
+    "type" : "choice",
+    "default" : "flex-end"
   } ],
   "tab" : "CONTENT",
   "expanded" : false,
@@ -84,6 +94,7 @@
       "src" : "",
       "alt" : null,
       "loading" : "disabled"
-    }
+    },
+    "alignment" : "flex-end"
   }
 } ]

--- a/version_control/Codurance_September2020/modules/Header Slice.module/meta.json
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/meta.json
@@ -2,6 +2,6 @@
   "global" : false,
   "smart_type" : "NOT_SMART",
   "host_template_types" : [ "PAGE" ],
-  "module_id" : 38658511762,
+  "module_id" : 38663813308,
   "is_available_for_new_content" : true
 }

--- a/version_control/Codurance_September2020/modules/Header Slice.module/meta.json
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global" : false,
+  "smart_type" : "NOT_SMART",
+  "host_template_types" : [ "PAGE" ],
+  "module_id" : 38658511762,
+  "is_available_for_new_content" : true
+}

--- a/version_control/Codurance_September2020/modules/Header Slice.module/module.css
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/module.css
@@ -1,0 +1,50 @@
+.header-slice {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  overflow: hidden;
+}
+
+@media (min-width: 1300px) {
+  .heading-slice__heading-wrapper {
+    max-width: 550px;
+    margin-right: 100px;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1299px) {
+  .heading-slice__heading-wrapper {
+    max-width: 49%;
+    margin-right: 60px;
+  }
+}
+
+.header-slice__heading {
+  font-size: 2.333rem;
+  font-weight: 700;
+  line-height: 3.2rem;
+  margin-bottom: 34px;
+}
+
+.header-slice__body-text {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin-bottom: 0;
+  padding-bottom: 50px;
+}
+
+.header-slice__image-wrapper {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  max-height: 350px;
+}
+.header-slice__image-wrapper > svg {
+  height: auto;
+  width: 100%;
+}
+@media (max-width: 1023px) {
+  .header-slice__image-wrapper {
+    display: none;
+  }
+}

--- a/version_control/Codurance_September2020/modules/Header Slice.module/module.css
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/module.css
@@ -33,7 +33,6 @@
 }
 
 .header-slice__image-wrapper {
-  align-items: flex-end;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/version_control/Codurance_September2020/modules/Header Slice.module/module.html
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/module.html
@@ -1,0 +1,10 @@
+<h1>{{module.heading}}</h1>
+<p>{{module.body_text}}</p>
+
+{% if module.image.image_type == 'linked_image' %}
+  <img src="{{module.image.linked_image.src}}" alt="" />
+{% endif %}
+
+{% if module.image.image_type == 'svg_code' %}
+  {{module.image.svg_code}}
+{% endif %}

--- a/version_control/Codurance_September2020/modules/Header Slice.module/module.html
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/module.html
@@ -1,10 +1,16 @@
-<h1>{{module.heading}}</h1>
-<p>{{module.body_text}}</p>
+<div class="header-slice">
+  <div class="heading-slice__heading-wrapper">
+    <h1 class="header-slice__heading">{{module.heading}}</h1>
+    <p class="header-slice__body-text">{{module.body_text}}</p>
+  </div>
 
-{% if module.image.image_type == 'linked_image' %}
-  <img src="{{module.image.linked_image.src}}" alt="" />
-{% endif %}
+  <div class="header-slice__image-wrapper">
+    {% if module.image.image_type == 'linked_image' %}
+      <img class="header-slice__linked-image" src="{{module.image.linked_image.src}}" alt="" />
+    {% endif %}
 
-{% if module.image.image_type == 'svg_code' %}
-  {{module.image.svg_code}}
-{% endif %}
+    {% if module.image.image_type == 'svg_code' %}
+      {{module.image.svg_code}}
+    {% endif %}
+  </div>
+</div>

--- a/version_control/Codurance_September2020/modules/Header Slice.module/module.html
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/module.html
@@ -4,7 +4,7 @@
     <p class="header-slice__body-text">{{module.body_text}}</p>
   </div>
 
-  <div class="header-slice__image-wrapper">
+  <div class="header-slice__image-wrapper" style="align-items: {{module.image.alignment}};">
     {% if module.image.image_type == 'linked_image' %}
       <img class="header-slice__linked-image" src="{{module.image.linked_image.src}}" alt="" />
     {% endif %}

--- a/version_control/Codurance_September2020/templates/events.html
+++ b/version_control/Codurance_September2020/templates/events.html
@@ -21,6 +21,10 @@
 
 {% block body %}
 
+<section class="events-header-slice">
+  {% module "events_header_slice" path="../modules/Header Slice.module" label="Page Header Slice" no_wrapper=True %}
+</section>
+
 <main>
   <section class="event-slider">
     <div

--- a/version_control/Codurance_September2020/templates/events.html
+++ b/version_control/Codurance_September2020/templates/events.html
@@ -21,7 +21,7 @@
 
 {% block body %}
 
-<section class="events-header-slice">
+<section class="events-header-slice responsive-page-width lateral-spacing">
   {% module "events_header_slice" path="../modules/Header Slice.module" label="Page Header Slice" no_wrapper=True %}
 </section>
 


### PR DESCRIPTION
This PR adds a new module to the Events Page template. This new module acts as the intro section of the page according to [the designs](https://xd.adobe.com/view/5aab813e-ae91-4831-9ed8-4c992d9181de-0ff8/). 