### PR TITLE
Remove unused fonts

### DIFF
--- a/version_control/Codurance_September2020/templates/layouts/base.html
+++ b/version_control/Codurance_September2020/templates/layouts/base.html
@@ -15,7 +15,6 @@
       overall number of calls -- here, you can use a single call to the gFonts api to get all the fonts you need
       https://developers.google.com/fonts/docs/getting_started
     #}
-    {{ require_css("https://fonts.googleapis.com/css?family=Merriweather:400,700|Lato:400,700&display=swap") }}
     {# Include Theme Overrides #}
     {{ require_js(get_asset_url("../../js/main.js")) }}
     {{ standard_header_includes }}


### PR DESCRIPTION
There are two fonts referenced in the head that we are not using. These have been removed to reduce load time and page weight