### PR TITLE
Correct menu opening bug

### DIFF
--- a/version_control/Codurance_September2020/modules/menu-section.module/module.html
+++ b/version_control/Codurance_September2020/modules/menu-section.module/module.html
@@ -36,10 +36,15 @@
 }}
 {% endmacro %}
 
-{% macro link(node) %}
+{% macro includeAriaControls(index) %}
+{{
+  {"aria-controls": "sub-menu-services" + index}|xmlattr
+}}
+{% endmacro %}
 
+{% macro link(node) %}
 <li {{ childClasses() if node.children else defaultItemClasses() }}>
-  <a href="{{ node.url if node.url else 'javascript:;' }}" class="menu-link trigger" {{ activeBranch() if node.activeBranch }} {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }} id="sub-menu-toggle{{loop.index}}" aria-controls="sub-menu-services{{loop.index}}" aria-expanded="false">{{ node.label }}</a>
+  <a href="{{ node.url if node.url else 'javascript:;' }}" class="menu-link trigger" {{ activeBranch() if node.activeBranch }} {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }} id="sub-menu-toggle{{loop.index}}" {{ includeAriaControls(loop.index) if level < 2 }} aria-expanded="false">{{ node.label }}</a>
   {% if node.children %}
   {{ renderNavigation(node) }}
   {% endif %}


### PR DESCRIPTION
This PR fixes the following [ticket](https://codurance-online.leankit.com/card/1415873736).

The issue was that the loops created within the macro were setting the links within sub-menus to have an `aria-controls` attribute that pointed to existing sub-menu id's.

This meant that when clicking the second link within the Services tab, the navbar would not close. Clicking the Our Story link would cause the Services sub-menu to open. 