### PR TITLE
Upcoming events translation text

### DIFF
--- a/version_control/Codurance_September2020/css/card-slider.css
+++ b/version_control/Codurance_September2020/css/card-slider.css
@@ -100,6 +100,7 @@
 }
 .card-slider__translation-info small {
   font-size: 1rem;
+  line-height: 1.1;
 }
 
 .card-slider__filter {

--- a/version_control/Codurance_September2020/css/card-slider.css
+++ b/version_control/Codurance_September2020/css/card-slider.css
@@ -86,6 +86,7 @@
 }
 @media (max-width: 1023px) {
   .card-slider__translation-info {
+    margin-top: -30px;
   }
 }
 .card-slider__translation-info::before {

--- a/version_control/Codurance_September2020/css/card-slider.css
+++ b/version_control/Codurance_September2020/css/card-slider.css
@@ -12,9 +12,10 @@
 }
 
 .card-slider__header-wrapper {
-  align-items: baseline;
+  align-items: flex-start;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 @media (max-width: 767px) {
   .card-slider__header-wrapper {
@@ -34,6 +35,24 @@
 @media (max-width: 767px) {
   .card-slider__heading {
     width: 100%;
+  }
+}
+
+@media (min-width: 1024px) {
+  .card-slider__nav-button-wrapper {
+    display: none;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .card-slider__nav-button-wrapper {
+    display: flex;
+    justify-content: right;
+    width: 50%;
+  }
+}
+@media (max-width: 767px) {
+  .card-slider__nav-button-wrapper {
+    display: none;
   }
 }
 
@@ -57,15 +76,29 @@
 .card-slider__nav-button > svg {
   width: 8px;
 }
-@media (min-width: 1024px) {
-  .card-slider__nav-button {
-    display: none;
+
+.card-slider__translation-info {
+  color: white;
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 30px;
+  width: 415px;
+}
+@media (max-width: 1023px) {
+  .card-slider__translation-info {
   }
 }
-@media (max-width: 767px) {
-  .card-slider__nav-button {
-    display: none;
-  }
+.card-slider__translation-info::before {
+  background-image: url({{ get_asset_url('../images/icon-information.svg' ) }});
+  background-repeat: no-repeat;
+  content: "";
+  display: inline-block;
+  height: 35px;
+  margin: auto 0;
+  width: 95px;
+}
+.card-slider__translation-info small {
+  font-size: 1rem;
 }
 
 .card-slider__filter {

--- a/version_control/Codurance_September2020/images/icon-information.svg
+++ b/version_control/Codurance_September2020/images/icon-information.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 35 35">
+  <g id="Group_2365" data-name="Group 2365" transform="translate(-859 -1355)">
+    <g id="Ellipse_162" data-name="Ellipse 162" transform="translate(859 1355)" fill="none" stroke="#fff" stroke-width="1">
+      <circle cx="17.5" cy="17.5" r="17.5" stroke="none"/>
+      <circle cx="17.5" cy="17.5" r="17" fill="none"/>
+    </g>
+    <text id="i" transform="translate(873 1380)" fill="#fff" font-size="23" font-family="Rockwell-Regular, Rockwell" letter-spacing="0.003em"><tspan x="0" y="0">i</tspan></text>
+  </g>
+</svg>

--- a/version_control/Codurance_September2020/js/cardSlider.js
+++ b/version_control/Codurance_September2020/js/cardSlider.js
@@ -91,10 +91,10 @@ class CardSlider {
 
   setUpEventListeners() {
     window.addEventListener('resize', this.handleResize);
-    this.cardWindow.addEventListener('mousedown', this.handleMouseDown);
+    this.track.addEventListener('mousedown', this.handleMouseDown);
     this.cardWindow.addEventListener('mouseup', this.handleMouseUp);
     this.cardWindow.addEventListener('mouseleave', this.handleMouseUp);
-    this.cardWindow.addEventListener('touchstart', this.handleMouseDown);
+    this.track.addEventListener('touchstart', this.handleMouseDown);
     this.cardWindow.addEventListener('touchend', this.handleMouseUp);
     if (this.navigationControl) {
       this.leftButton.addEventListener('click', this.navigateLeft);

--- a/version_control/Codurance_September2020/modules/Header Slice.module/module.css
+++ b/version_control/Codurance_September2020/modules/Header Slice.module/module.css
@@ -37,6 +37,7 @@
   flex-direction: row;
   justify-content: center;
   max-height: 350px;
+  width: 100%;
 }
 .header-slice__image-wrapper > svg {
   height: auto;

--- a/version_control/Codurance_September2020/modules/Past Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Past Events Listing.module/module.html
@@ -11,7 +11,7 @@ previousEventsFilter) %}
     <h2 class="card-slider__heading responsive-page-width">
       {{module.heading}}
     </h2>
-    <div>
+    <div class="card-slider__nav-button-wrapper">
       <button
         class="card-slider__nav-button"
         autocomplete="off"

--- a/version_control/Codurance_September2020/modules/Services Media.module/module.css
+++ b/version_control/Codurance_September2020/modules/Services Media.module/module.css
@@ -37,3 +37,9 @@
     top: -200px;
   }
 }
+
+@media (max-width: 767px) {
+  .services-media__watch-all-cta {
+    padding-top: 60px;
+  }
+}

--- a/version_control/Codurance_September2020/modules/Services Media.module/module.html
+++ b/version_control/Codurance_September2020/modules/Services Media.module/module.html
@@ -111,7 +111,7 @@
       </div>
     </div>
   </div>
-  <div data-watch-all-cta="video" class="hidden">
+  <div class="hidden services-media__watch-all-cta" data-watch-all-cta="video">
     <a
       class="card-slider__watch-all-button"
       href="https://www.youtube.com/c/Codurance/playlists"
@@ -119,7 +119,7 @@
       >{{module.videos.cta_text}}</a
     >
   </div>
-  <div data-watch-all-cta="podcast" class="hidden">
+  <div class="hidden services-media__watch-all-cta" data-watch-all-cta="podcast">
     <a
       class="card-slider__watch-all-button"
       href="https://www.codurance.com/publications/tag/podcasts"

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/fields.json
@@ -17,6 +17,15 @@
   "type" : "text",
   "default" : "Upcoming Events"
 }, {
+  "id" : "68cd05f2-138b-2241-0169-db614bd61760",
+  "name" : "translation_information_text",
+  "label" : "Translation Information Text",
+  "required" : false,
+  "locked" : false,
+  "display" : "checkbox",
+  "type" : "boolean",
+  "default" : false
+}, {
   "id" : "898cb49a-3b14-3cc2-1126-5b2b1bdd300b",
   "name" : "space_filling_cta_text",
   "label" : "Space-filling CTA Text",

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -11,7 +11,7 @@ upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
     <h2 class="card-slider__heading responsive-page-width">
       {{module.heading}}
     </h2>
-    <div>
+    <div class="card-slider__nav-button-wrapper">
       <button
         class="card-slider__nav-button"
         autocomplete="off"
@@ -67,6 +67,9 @@ upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
           </g>
         </svg>
       </button>
+    </div>
+    <div class="card-slider__translation-info">
+      <small>Nuestros eventos son, en su mayoría, en inglés. Por eso estás viendo sus títulos y descripciones en este idioma.</small>
     </div>
   </div>
   <div class="card-slider-results" data-upcoming-card-track>

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -68,9 +68,11 @@ upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
         </svg>
       </button>
     </div>
-    <div class="card-slider__translation-info">
-      <small>Nuestros eventos son, en su mayoría, en inglés. Por eso estás viendo sus títulos y descripciones en este idioma.</small>
-    </div>
+    {% if module.translation_information_text %}
+      <div class="card-slider__translation-info">
+        <small>Nuestros eventos son, en su mayoría, en inglés. Por eso estás viendo sus títulos y descripciones en este idioma.</small>
+      </div>
+    {% endif %}
   </div>
   <div class="card-slider-results" data-upcoming-card-track>
     {% for event in upcomingEvents %}


### PR DESCRIPTION
this pr:
-  fixes an issue with the image in the header slice of the events page, in chrome and edge
- adds an optional information block to the upcoming events, about our events being in english (for the spanish page)
- fixes a visual issue with the watch all/listen to all cta in the services media in mobile view
- only allows card swipe tracking from within card track

you should be able to see these tested in the staging account event page and service page