### PR TITLE
fill available with header slice image for chrome

### DIFF
--- a/version_control/Codurance_September2020/css/modules/header-slice.css
+++ b/version_control/Codurance_September2020/css/modules/header-slice.css
@@ -37,7 +37,6 @@
   flex-direction: row;
   justify-content: center;
   max-height: 350px;
-  width: 100%;
   width: -moz-available;
   width: -webkit-fill-available;
   width: fill-available;

--- a/version_control/Codurance_September2020/css/modules/header-slice.css
+++ b/version_control/Codurance_September2020/css/modules/header-slice.css
@@ -37,6 +37,10 @@
   flex-direction: row;
   justify-content: center;
   max-height: 350px;
+  width: 100%;
+  width: -moz-available;
+  width: -webkit-fill-available;
+  width: fill-available;
 }
 .header-slice__image-wrapper > svg {
   height: auto;


### PR DESCRIPTION
If you open the [event page](https://www.codurance.com/events/) in chrome, the image is super small
This change makes the image fill the space