### PR TITLE
added  header to contact-us

### DIFF
--- a/version_control/Codurance_September2020/templates/contact-us.html
+++ b/version_control/Codurance_September2020/templates/contact-us.html
@@ -27,6 +27,9 @@ label: Contact Us Page
 {% block body %}
 <div class="hs-contact-us-layout">
   <main class="body-container-wrapper">
+  <section>
+  {% module "simple-hero-slice" path="../modules/simple-hero-slice.module" label="" no_wrapper=True %}
+  </section>
     {% dnd_area "dnd_area1" class='hs-contact-us-section1', label='Section 1' %}
     {% end_dnd_area %}
     <div class="hs-get-in-touch-section" id="get-in-touch">


### PR DESCRIPTION
I've added the header module to the contact-us page template. We have to consider also maybe futurewise add in this template the contact us cards. 