### PR TITLE
Page/case study template

### DIFF
--- a/version_control/Codurance_September2020/css/modules/job-listing-card.css
+++ b/version_control/Codurance_September2020/css/modules/job-listing-card.css
@@ -13,3 +13,9 @@
     padding: 2rem;
 }
 
+{% call utils.small() %}
+    .job-card { 
+        margin-bottom: 1.5em;
+    }
+{% endcall %}
+

--- a/version_control/Codurance_September2020/css/pages/case-study-template.css
+++ b/version_control/Codurance_September2020/css/pages/case-study-template.css
@@ -1,0 +1,119 @@
+{% import '../utils/utils.css' as utils %}
+
+.form__wrapper{
+    {{utils.black_to_navy()}}
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: white;
+    padding: 2em 1.5em;
+}
+
+.form__text{
+    max-width: 40ch;
+    font-size: 16px;
+}
+
+.form__wrapper .legal-consent-container p{
+    color: white;
+ }
+
+.form__fields .hs-form fieldset.form-columns-2 .hs-input {
+  width: 100% !important;
+}
+
+.form__fields .hs-input {
+    {{ utils.card_shadow() }}
+}
+
+.form__fields .hs-fieldtype-text{
+    margin-bottom: 0.5em;
+}
+
+.form__fields input[type="checkbox"] {
+  opacity: 0.0001;
+  margin-right: 1em;
+}
+
+.form__fields .hs-form-booleancheckbox-display{
+    align-items: start;
+    {{ utils.sejima() }}
+    font-weight: normal;
+    color: var(--shark);
+    margin-bottom: 1em;
+    max-width: 98%;
+}
+
+.form__fields .hs-form-booleancheckbox-display span {
+  position: relative;
+}
+
+.form__fields .hs-form-booleancheckbox-display span::before {
+  position: absolute;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, .25);
+  content: "";
+  height: 1rem;
+  width: 1rem;
+  top: 0.2em;
+  left: -2.1em;
+  background: white;
+  {{ utils.card_shadow() }}
+}
+
+.form__fields input[type=checkbox]:focus + span:before {
+  outline: rgb(0, 0, 0) auto 5px;
+}
+
+
+.form__fields .hs-form-booleancheckbox-display span::after {
+  position: absolute;
+  border-bottom: 2px solid;
+  border-left: 2px solid;
+  display: inline-block;
+  transform: rotate(-45deg);
+  height: 0.4rem;
+  width: 0.6rem;
+  left: -1.9em;
+  top: 0.5em;
+}
+
+.form__fields input[type=checkbox]:checked + span::after {
+  content: "";
+}
+
+.form__fields .hs-button{
+    width: 98%;
+}
+
+.form__fields .legal-consent-container p{
+  {{utils.sejima()}}
+  font-weight:var(--light-font-weight);
+}
+
+.form__fields .legal-consent-container .hs-form-booleancheckbox-display > span{
+  margin-left: 0 !important;
+}
+
+
+.footer{
+    max-width: 1300px;
+    margin: auto;
+}
+
+{% call utils.medium_large_and_extra_large() %}
+    .form__wrapper{
+        flex-direction: row;
+        align-items: start;
+        justify-content: space-between;
+        gap: 2em;
+        margin: 0 auto;
+        max-width: 1300px;
+        padding: 4em;
+    }
+
+    .form__text{
+        max-width: 40%;
+        margin-right: 2em;
+    }
+{% endcall %}

--- a/version_control/Codurance_September2020/modules/LP-form-two-columns.module/fields.json
+++ b/version_control/Codurance_September2020/modules/LP-form-two-columns.module/fields.json
@@ -24,9 +24,9 @@
   "locked" : false,
   "type" : "form",
   "default" : {
-    "form_id" : "2e50636a-5a3c-44e9-8571-377d15f2f19d",
-    "response_type" : "inline",
-    "message" : "Thank you for submitting the form.",
+    "form_id" : "",
+    "response_type" : "redirect",
+    "message" : "",
     "gotowebinar_webinar_key" : null,
     "form_type" : "HUBSPOT"
   }

--- a/version_control/Codurance_September2020/templates/case-study-template.html
+++ b/version_control/Codurance_September2020/templates/case-study-template.html
@@ -1,0 +1,18 @@
+<!--
+    templateType: page
+    isAvailableForNewContent: true
+-->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>{{ content.html_title }}</title>
+    <meta name="description" content="{{ content.meta_description }}">
+    {{ standard_header_includes }}
+  </head>
+  <body>
+    {% module "page_template_logo" path="@hubspot/logo" label="Logo" %}
+    {% module "page_template_rich_text" path="@hubspot/rich_text" label="Rich Text" %}
+    {{ standard_footer_includes }}
+  </body>
+</html>

--- a/version_control/Codurance_September2020/templates/case-study-template.html
+++ b/version_control/Codurance_September2020/templates/case-study-template.html
@@ -1,18 +1,47 @@
+
 <!--
-    templateType: page
-    isAvailableForNewContent: true
+templateType: page
+isAvailableForNewContent: true
+label: Case study template
 -->
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>{{ content.html_title }}</title>
-    <meta name="description" content="{{ content.meta_description }}">
-    {{ standard_header_includes }}
-  </head>
-  <body>
-    {% module "page_template_logo" path="@hubspot/logo" label="Logo" %}
-    {% module "page_template_rich_text" path="@hubspot/rich_text" label="Rich Text" %}
-    {{ standard_footer_includes }}
-  </body>
-</html>
+{% extends "./layouts/base.html" %}
+<head>
+  <meta charset="utf-8">
+  <title>{{ page_meta.html_title }}</title>
+  {% if site_settings.favicon_src %}
+    <link rel="shortcut icon" href="{{ site_settings.favicon_src }}" />
+  {% endif %}
+
+  <meta name="description" content="{{ page_meta.meta_description }}">
+  {{ require_css(get_asset_url("../css/layout.css")) }}
+  {{ require_css(get_asset_url("../css/main.css")) }}
+  {{ require_css(get_asset_url("../css/base/base-styles.css")) }}
+
+  {{ require_css(get_asset_url("../css/pages/case-study-template.css")) }}
+
+  {{ require_js(get_asset_url("../js/main.js")) }}
+  {{ standard_header_includes }}
+  {{ require_css(get_asset_url("../css/FontAwesome.css")) }}
+  {{ require_css(get_asset_url("../css/theme-overrides.css")) }}
+</head>
+
+{% block body %}
+
+<div class="case-study">
+  {% module "Main Banner" path="../modules/LP-cta-block", 
+          label="" no_wrapper=True %}
+   <section>
+     <div class="form__wrapper">
+       <div class="form__text">
+         {% module "case_study_description" path="@hubspot/rich_text"
+             label="Case Study Description" no_wrapper=True %}
+       </div>
+        <div class="form__fields">
+          {% module "form" path="@hubspot/form" %}
+        </div>
+      </div>
+   </section>
+
+   </div>  
+{% endblock body %}
+


### PR DESCRIPTION
Currently, we had problems when using a form in a module as a field, not responding to the redirection of the pages and also not showing the follow-up email checkbox on the Hubspot UI builder. 
Therefore I had to create a template with the same elements to meet the requirements of the team and Hubspot to make it work.