### PR TITLE
Fix/wrong link careers page

### DIFF
--- a/version_control/Codurance_September2020/css/modules/text-image-default.css
+++ b/version_control/Codurance_September2020/css/modules/text-image-default.css
@@ -15,14 +15,15 @@
 
 .cm-text-img__rich-text {
     max-width: 52ch;
-    {{ utils.natus() }}
-        
 }
-    
+
 .cm-text-img__rich-text h2{
     {{ utils.freed() }}
     margin-bottom: .5em;
+}
 
+.cm-text-img__rich-text p{
+    {{ utils.natus() }}
 }
     
 .cm-text-img__image {
@@ -44,6 +45,10 @@
     .cm-text-img__image {
         max-width: 45%;
     }   
+
+    .cm-text-img__rich-text p{
+        {{ utils.base() }}
+    }
 {% endcall %}
 
 

--- a/version_control/Codurance_September2020/templates/our-people.html
+++ b/version_control/Codurance_September2020/templates/our-people.html
@@ -31,11 +31,13 @@ label: Our People
     {% set header_title = 'Nuestro equipo' %}
     {% set footer_heading = 'Buscamos talento' %}
     {% set footer_text = '¿Quieres trabajar con autonomía y tienes el propósito de mejorar día a día en tu carrera profesional? Nos gustaría conocerte y compartir contigo nuestros valores de pragmatismo, profesionalidad y transparencia.' %}
+    {% set footer_href = 'https://www.codurance.com/es/careers/' %}    
     {% set footer_cta = 'Infórmate' %}    
   {% else %}
     {% set header_title = 'Our People' %}
     {% set footer_heading = 'We are hiring' %}
     {% set footer_text = 'Are you looking for autonomy, mastery and purpose in your career? We are looking for people that share the same values of pragmatism, professionalism and transparency that we do.' %}
+    {% set footer_href = 'https://www.codurance.com/careers/' %}
     {% set footer_cta = 'Learn More' %}
   {% endif %}
 
@@ -52,7 +54,7 @@ label: Our People
         <h2>{{ footer_heading }}</h2>
         <p>{{ footer_text }}</p>
       </div>
-      <a class="button-primary our-people__hiring-cta" href="https://www.codurance.com/careers/">{{ footer_cta }}</a>
+      <a class="button-primary our-people__hiring-cta" href={{ footer_href }}>{{ footer_cta }}</a>
     </div>
   </div>
   


### PR DESCRIPTION
Currently, there was an issue on the bottom banner of the "Our people" Spanish page, redirecting to the English site when clicking the button instead of the ES site.

Also I fixed the font size on small screens in the default text and image module.