### PR TITLE
Adjustments to LP Testimonial Slider Module

### DIFF
--- a/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.html
+++ b/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.html
@@ -46,10 +46,6 @@
           {% if module.testimonial_items|length > 1 %}
             <div class="swiper-button-next"></div>
             <div class="swiper-button-prev"></div>
-          {% else %} 
-            <script>
-              var swiperOneSlide = true;
-            </script>
           {% endif %}
 
           <div class="swiper-pagination"></div>

--- a/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.html
+++ b/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.html
@@ -42,8 +42,16 @@
             </div>
           {% endfor %}
           </div>
-          <div class="swiper-button-next"></div>
-          <div class="swiper-button-prev"></div>
+
+          {% if module.testimonial_items|length > 1 %}
+            <div class="swiper-button-next"></div>
+            <div class="swiper-button-prev"></div>
+          {% else %} 
+            <script>
+              var swiperOneSlide = true;
+            </script>
+          {% endif %}
+
           <div class="swiper-pagination"></div>
         </div>
       </div>

--- a/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.js
+++ b/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.js
@@ -1,25 +1,27 @@
-/* The swiper slider of the module will only be created
-if there is more than one slide */
-if(typeof swiperOneSlide == "undefined"){
-  let swiper = new Swiper(".swiper", {
-    slidesPerView: 1,
-    spaceBetween: 30,
-    loop: true,
-    watchOverflow: true,
-    grabCursor: true,
-    navigation: {
-      nextEl: '.swiper-button-next',
-      prevEl: '.swiper-button-prev',
-    },
-    pagination: {
-      el: ".swiper-pagination",
-      clickable: true,
-    },
-    keyboard: {
-      enabled: true,
-    },
-  });
-}
+let swiper = new Swiper(".swiper", {
+  slidesPerView: 1,
+  spaceBetween: 30,
+  loop: true,
+  watchOverflow: true,
+  grabCursor: true,
+  navigation: {
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
+  },
+  pagination: {
+    el: ".swiper-pagination",
+    clickable: true,
+  },
+  keyboard: {
+    enabled: true,
+  },
+});
 
+/* Check the number of slides on the swiper slider and
+disable it if there's just a single one (in that case,
+the length would be 3 due to the loop property) */
+if(swiper.slides.length == 3) {
+  swiper.destroy();
+}
 
 

--- a/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.js
+++ b/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.js
@@ -17,10 +17,9 @@ let swiper = new Swiper(".swiper", {
   },
 });
 
-/* Check the number of slides on the swiper slider and
-disable it if there's just a single one (in that case,
-the length would be 3 due to the loop property) */
-if(swiper.slides.length == 3) {
+const minimumSlidesAvailable = 3;
+
+if(swiper.slides.length == minimumSlidesAvailable) {
   swiper.destroy();
 }
 

--- a/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.js
+++ b/version_control/Codurance_September2020/modules/Landing Page Modules/LP-testimonial-slider.module/module.js
@@ -1,9 +1,11 @@
-
-
-var swiper = new Swiper(".swiper", {
+/* The swiper slider of the module will only be created
+if there is more than one slide */
+if(typeof swiperOneSlide == "undefined"){
+  let swiper = new Swiper(".swiper", {
     slidesPerView: 1,
     spaceBetween: 30,
     loop: true,
+    watchOverflow: true,
     grabCursor: true,
     navigation: {
       nextEl: '.swiper-button-next',
@@ -17,3 +19,7 @@ var swiper = new Swiper(".swiper", {
       enabled: true,
     },
   });
+}
+
+
+


### PR DESCRIPTION
This module has been configured in order to apply the following changes to the slider when it just contains a single slide:

- Don't display the horizontal navigation arrows
- Disable the slider (specifically, the swiper slider object itself will not be created) 