### PR TITLE
Update: case study text on clients page

### DIFF
--- a/version_control/Codurance_September2020/partials/clients-page-cards.html
+++ b/version_control/Codurance_September2020/partials/clients-page-cards.html
@@ -2,7 +2,7 @@
 
 {% if locale == 'en' %}
     {% set promotion_text = "Find out how we helped" %} 
-    {% set case_study_button_text = "Download Case Study" %}  
+    {% set case_study_button_text = "Read Case Study" %}  
     {% set case_study_info_text = "Find out how we helped" %}  
     {% set proposition_job_title = "at" %}        
   {% else %}


### PR DESCRIPTION
The marketing team requested to change the default text in the clients page, from "Download Case Study" to "Read Case Study". 