### PR TITLE
Fix menu logo redirection url on click to be the right lang

### DIFF
--- a/version_control/Codurance_September2020/templates/landing-page-template.html
+++ b/version_control/Codurance_September2020/templates/landing-page-template.html
@@ -45,8 +45,6 @@ label: Landing Page Template
                             <img src="https://www.codurance.com/hubfs/raw_assets/public/Codurance_September2020/images/Logo.svg" class="hs-image-widget " style="width:719px;border-width:0px;border:0px;" width="719" alt="Codurance" title="Codurance">
                         </a>
                     </div>
-                    <h2>{{locale}}</h2>
-                    <h2>{{url}}</h2>
                 </div>
             </div>
         </header>

--- a/version_control/Codurance_September2020/templates/landing-page-template.html
+++ b/version_control/Codurance_September2020/templates/landing-page-template.html
@@ -5,12 +5,12 @@ label: Landing Page Template
 -->
 {% extends "./layouts/base.html" %}
 
-{% if locale == 'en' %}
-    {% set url = "https://www.codurance.com/" %}               
-  {% else %}
-    {% set url = "https://www.codurance.com/es" %} 
+{% set url_redirection = "https://www.codurance.com/" %}               
 
+{% if locale == 'es' %}
+    {% set url_redirection = "https://www.codurance.com/es" %} 
 {% endif %}
+
 
 <head>
   <meta charset="utf-8">
@@ -41,10 +41,12 @@ label: Landing Page Template
             <div class="cm-header-group">
                 <div class="header__container">
                     <div class="custom-logo">
-                        <a href={{url}}>
+                        <a href={{ url_redirection }}>
                             <img src="https://www.codurance.com/hubfs/raw_assets/public/Codurance_September2020/images/Logo.svg" class="hs-image-widget " style="width:719px;border-width:0px;border:0px;" width="719" alt="Codurance" title="Codurance">
                         </a>
                     </div>
+                    <h2>{{locale}}</h2>
+                    <h2>{{url}}</h2>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
The redirection to the homepage when clicking on the logo of the landing pages were always pointing to the '/es' site. We've changed the conditional to fix the issue.