### PR TITLE
Change toggle min width

### DIFF
--- a/version_control/Codurance_September2020/css/modules/our-people-listing.css
+++ b/version_control/Codurance_September2020/css/modules/our-people-listing.css
@@ -29,7 +29,7 @@
   background-color: var(--french-gray);
   border-radius: 12px;
   height: 1.2rem;
-  width: 2.2rem;
+  min-width: 2.2rem;
   position: relative;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
When the filter section has a long text description for it, the toggle seemed to be shrinking on mobile devices. We had to set up a min width to fix it.