### PR TITLE
Block enter key on the search bar to prevent submit

### DIFF
--- a/version_control/Codurance_September2020/modules/Events-Search-Bar.module/module.js
+++ b/version_control/Codurance_September2020/modules/Events-Search-Bar.module/module.js
@@ -4,8 +4,15 @@ const searchBarForm = document.querySelector(".events-search-bar");
 const searchBar = searchBarForm.querySelector(".events-search-bar__input");
 const searchBarResetButton = searchBarForm.querySelector(".events-search-bar__reset-button");
 
+searchBar.addEventListener("keypress", blockEnterKey);
 searchBar.addEventListener("input", filterEventsOnInputValueChange);
 searchBarResetButton.addEventListener("click", filterEventsOnResetButtonClick);
+
+function blockEnterKey(keypressEvent) {
+    // The 13 key code corresponds to the enter key
+    if (keypressEvent.keyCode == 13)
+        keypressEvent.preventDefault();
+}
 
 function filterEventsOnInputValueChange(inputEvent) {
     const searchBarText = inputEvent.target.value;

--- a/version_control/Codurance_September2020/modules/Events-Search-Bar.module/module.js
+++ b/version_control/Codurance_September2020/modules/Events-Search-Bar.module/module.js
@@ -4,11 +4,11 @@ const searchBarForm = document.querySelector(".events-search-bar");
 const searchBar = searchBarForm.querySelector(".events-search-bar__input");
 const searchBarResetButton = searchBarForm.querySelector(".events-search-bar__reset-button");
 
-searchBar.addEventListener("keypress", blockEnterKey);
+searchBar.addEventListener("keypress", dismissEnterKey);
 searchBar.addEventListener("input", filterEventsOnInputValueChange);
 searchBarResetButton.addEventListener("click", filterEventsOnResetButtonClick);
 
-function blockEnterKey(keypressEvent) {
+function dismissEnterKey(keypressEvent) {
     // The 13 key code corresponds to the enter key
     if (keypressEvent.keyCode == 13)
         keypressEvent.preventDefault();


### PR DESCRIPTION
The search bar filter on the videos page refreshed the page when the enter key was pressed on it, so we've blocked this key to avoid that