### PR TITLE
Set default options on register your interest modules

### DIFF
--- a/version_control/Codurance_September2020/modules/LP-cta-block.module/fields.json
+++ b/version_control/Codurance_September2020/modules/LP-cta-block.module/fields.json
@@ -22,7 +22,7 @@
     "type" : "image",
     "default" : {
       "size_type" : "auto",
-      "src" : "",
+      "src" : "https://www.codurance.com/hubfs/Careers%20Page/Overview/CTA%20block/cta-bg-dark.svg",
       "alt" : null,
       "loading" : "lazy"
     }
@@ -41,7 +41,7 @@
     "type" : "image",
     "default" : {
       "size_type" : "auto",
-      "src" : "",
+      "src" : "https://www.codurance.com/hubfs/Careers%20Page/Overview/CTA%20block/cta-bg-dark.svg",
       "alt" : null,
       "loading" : "lazy"
     }

--- a/version_control/Codurance_September2020/templates/academy.html
+++ b/version_control/Codurance_September2020/templates/academy.html
@@ -40,13 +40,39 @@ label: Academy template
 {% boolean "gated_toggle" label='Academy campaign?', value='True', no_wrapper=True, export_to_template_context=True %}
 
   {% if widget_data.gated_toggle.value == True %}
+    {% set headline = "Want to join the next Academy?" %}
+    {% set cta_field = "10aeb14a-b86c-4abb-bc0e-f7bfd657a074" %}
+    
+    {% if locale == "es" %}
+      {% set headline = "¿Quieres formar parte del próximo Academy Program?" %}
+      {% set cta_field = "427e8052-a509-45ea-84a4-4a057a6de071" %}
+    {% endif %}
+
     {% module 'cta_block'
-      path='../modules/LP-cta-block.module'
-      label="Cta banner" %}
+      path='../modules/LP-cta-block.module',
+      label="Cta banner",
+      headline="{{ headline }}",
+      cta_field="{{ cta_field }}"
+    %}
   {% else %}
+    {% set form_title = "Register your interest for the next Academy" %}
+    {% set form_subtitle = "Sign up and receive an email when The Academy is open for applications" %}
+    {% set form_id = "78b19cd9-fe39-4dd4-a981-7e389e09c3a9" %}
+
+    {% if locale == "es" %}
+      {% set form_title = "¿Te interesa informarte sobre la próxima academia?" %}
+      {% set form_subtitle = "Suscríbete y recibe un correo cuando la academia esté abierta a nuevas inscripciones" %}
+      {% set form_id = "78da2f15-733b-46ec-b34f-c4568a910845" %}
+    {% endif %}
+
     {% module 'Form card'
-      path='../modules/Newsletter-Form-Card.module'
-      label="Form card" no_wrapper=True %}
+      path='../modules/Newsletter-Form-Card.module',
+      label="Form card", 
+      no_wrapper=True,
+      title="{{ form_title }}",
+      subtitle="{{ form_subtitle }}",
+      newsletter_form={ form_id: "{{ form_id }}" }
+    %}
   {% endif %}
 
 <section class="how-it-works__wrapper lateral-spacing">
@@ -55,13 +81,11 @@ label: Academy template
       path='../modules/Text-Image-Default.module'
       label="How it works Text and Image" no_wrapper=True %}
 
-  
   {% module 'How does it works'
     path='../modules/How-Does-It-Work.module'
     label="How does it work" no_wrapper=True %}
 
 </section>
-
 
 <section class="skills lateral-spacing">
   {% module 'Skills Text and image'


### PR DESCRIPTION
There was a bug on the register your interest modules: they reset the options when they are switched.

To avoid that, we've set the desired options as default on the invocation of modules at the corresponding template.