### PR TITLE
Change limit to 12 events shown on upcoming events

### DIFF
--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -3,7 +3,7 @@
 {{ require_css(get_asset_url("../../css/card-slider.css")) }}
 
 {% if module.hubdb_table %}
-  {% set upcomingEventsFilter = ("&orderBy=datetime" + "&datetime__gt=" + local_dt|unixtimestamp + "&limit=4") %}
+  {% set upcomingEventsFilter = ("&orderBy=datetime" + "&datetime__gt=" + local_dt|unixtimestamp + "&limit=12") %}
   {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
 
   {% if upcomingEvents|length > 0 %}


### PR DESCRIPTION
The marketing team requested to have a higher number of upcoming Events listed