### PR TITLE
Feature/blog-post/newsletter-popup-improvements

### DIFF
--- a/version_control/Codurance_September2020/css/modules/newsletter-footer-form.css
+++ b/version_control/Codurance_September2020/css/modules/newsletter-footer-form.css
@@ -1,7 +1,7 @@
 {% import '../utils/utils.css' as utils %}
 
 .newsletter-footer-form__section {
-    background: transparent linear-gradient(180deg,rgba(79,67,248,0.1) 0%,rgba(45,147,234,0.1) 100%) 0% 0% no-repeat padding-box;
+    {{ utils.tango_to_white() }}
 }
 
 .newsletter-footer-form__container {
@@ -15,9 +15,8 @@
 {% endcall %}
 @media (min-width: 481px) {
     .newsletter-footer-form__container {
-        align-items: center;
         display: flex;
-        flex-direction: row;
+        justify-content: center;
         margin: 0px auto;
         padding: 45px 0 100px;
         width: 90%;
@@ -44,10 +43,6 @@
     }
 {% endcall %}
 
-
-.newsletter-footer-form__wrapper {
-    z-index: 2;
-}
 @media (min-width: 481px) {
     .newsletter-footer-form__wrapper {
         width: calc(100% - 230px);
@@ -56,55 +51,5 @@
 {% call utils.small() %}
     .newsletter-footer-form__wrapper {
         width: 100%;
-        padding-top: 150px;
-    }
-{% endcall %}
-
-.newsletter-footer-form__image {
-    z-index: 1;
-}
-{% call utils.medium_large_and_extra_large() %}
-    .newsletter-footer-form__image {
-        height: 200px;
-        margin-left: -30px;
-        width: 260px;
-    }
-{% endcall %}
-{% call utils.small() %}
-    .newsletter-footer-form__image {
-        background-size: 175px 135px;
-        height: 135px;
-        left: 50%;
-        margin: 0;
-        position: absolute;
-        top: 50px;
-        transform: translateX(-50%);
-        width: 175px;
-    }
-{% endcall %}
-.newsletter-footer-form__image--pending {
-    background-image: url(https://f.hubspotusercontent10.net/hubfs/3042464/Newsletter%20Sign-Up%20Form/newsletter-graphic.svg);
-}
-{% call utils.small() %}
-    .newsletter-footer-form__image--pending {
-        width: 175px;
-    }
-{% endcall %}
-{% call utils.medium_large_and_extra_large() %}
-    .newsletter-footer-form__image--pending {
-        width: 260px;
-    }
-{% endcall %}
-.newsletter-footer-form__image--success {
-    background-image: url(https://f.hubspotusercontent10.net/hubfs/3042464/Newsletter%20Sign-Up%20Form/bg-form-success.svg);
-}
-{% call utils.small() %}
-    .newsletter-footer-form__image--success {
-        width: 180px;
-    }
-{% endcall %}
-{% call utils.medium_large_and_extra_large() %}
-    .newsletter-footer-form__image--success {
-        width: 320px;
     }
 {% endcall %}

--- a/version_control/Codurance_September2020/css/modules/newsletter-form-card.css
+++ b/version_control/Codurance_September2020/css/modules/newsletter-form-card.css
@@ -38,7 +38,7 @@
 }
 
 .newsletter-text-content__subtitle {
-    margin-top: var(--freed-margin);
+    margin-top: var(--sejima-margin);
 }
 
 .newsletter-content__icon {

--- a/version_control/Codurance_September2020/css/newsletter-form.css
+++ b/version_control/Codurance_September2020/css/newsletter-form.css
@@ -82,7 +82,8 @@
     }
 }
 
-.hs-email input {
+.newsletter-footer-form__section .hs-email input,
+.newsletter-exit-popup__container .hs-email input {
     {{ utils.base() }}
     box-shadow: 0px 0px 20px #00000029;
     border: 1px white solid;

--- a/version_control/Codurance_September2020/css/pages/blog-post.css
+++ b/version_control/Codurance_September2020/css/pages/blog-post.css
@@ -170,6 +170,11 @@
   font-family: monospace;
 }
 
+.newsletter > .newsletter-wrapper {
+  margin-top: 2.4em;
+  margin-bottom: 2.4em;
+}
+
 {% call utils.extra_large() %}
   .newsletter > .newsletter-wrapper {
     max-width: var(--base-max-width);
@@ -186,6 +191,10 @@
 
   .newsletter__form {
     align-self: flex-end;
+  }
+
+  .newsletter .newsletter__form .hs-form {
+    align-items: unset;
   }
 {% endcall %}
 

--- a/version_control/Codurance_September2020/css/pages/blog-post.css
+++ b/version_control/Codurance_September2020/css/pages/blog-post.css
@@ -170,6 +170,25 @@
   font-family: monospace;
 }
 
+{% call utils.extra_large() %}
+  .newsletter > .newsletter-wrapper {
+    max-width: var(--base-max-width);
+  }
+
+  .newsletter-wrapper > .newsletter-inner {
+    flex-flow: column;
+    max-width: 30rem;
+  }
+
+  .newsletter-text-content__title {
+    max-width: 20ch;
+  }
+
+  .newsletter__form {
+    align-self: flex-end;
+  }
+{% endcall %}
+
 .related-blog-section {
   background-color: var(--athens-gray);
 }

--- a/version_control/Codurance_September2020/css/pages/blog-post.css
+++ b/version_control/Codurance_September2020/css/pages/blog-post.css
@@ -170,17 +170,17 @@
   font-family: monospace;
 }
 
-.newsletter > .newsletter-wrapper {
+.newsletter .newsletter-wrapper {
   margin-top: 2.4em;
   margin-bottom: 2.4em;
 }
 
 {% call utils.extra_large() %}
-  .newsletter > .newsletter-wrapper {
+  .newsletter .newsletter-wrapper {
     max-width: var(--base-max-width);
   }
 
-  .newsletter-wrapper > .newsletter-inner {
+  .newsletter-wrapper .newsletter-inner {
     flex-flow: column;
     max-width: 30rem;
   }

--- a/version_control/Codurance_September2020/modules/Blog Post Banner Recruitment.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Blog Post Banner Recruitment.module/fields.json
@@ -1,10 +1,1 @@
-[ {
-  "id" : "f44f1ccf-ad5c-b80c-e6a9-475a5c6dec08",
-  "name" : "hide_recruitment_banner",
-  "label" : "hide-recruitment-banner",
-  "required" : false,
-  "locked" : false,
-  "display" : "toggle",
-  "type" : "boolean",
-  "default" : false
-} ]
+[ ]

--- a/version_control/Codurance_September2020/modules/Blog Post Banner Recruitment.module/module.html
+++ b/version_control/Codurance_September2020/modules/Blog Post Banner Recruitment.module/module.html
@@ -1,11 +1,9 @@
 {{ require_css(get_asset_url("../../css/modules/blog-post-banner-recruitment.css")) }}
 
-{% if !module.hide_recruitment_banner %}
-	<div class="banner-cta-container">
-		{% if locale == 'en' %}
+<div class="banner-cta-container">
+	{% if locale == 'en' %}
 			{% cta guid="53b93af5-4e36-469a-a09d-d115d369b9e2" no_wrapper=True %}
-		{% else %}
-			{% cta guid="23c250aa-5142-45f0-a881-f2c8acd27127" no_wrapper=True %}
-		{% endif %}
-	</div>
-{% endif %}
+	{% else %}
+		{% cta guid="23c250aa-5142-45f0-a881-f2c8acd27127" no_wrapper=True %}
+	{% endif %}
+</div>

--- a/version_control/Codurance_September2020/modules/Blog Post Banner Recruitment.module/module.html
+++ b/version_control/Codurance_September2020/modules/Blog Post Banner Recruitment.module/module.html
@@ -1,7 +1,6 @@
 {{ require_css(get_asset_url("../../css/modules/blog-post-banner-recruitment.css")) }}
 
 {% if !module.hide_recruitment_banner %}
-	<!-- HTML to show when checked -->
 	<div class="banner-cta-container">
 		{% if locale == 'en' %}
 			{% cta guid="53b93af5-4e36-469a-a09d-d115d369b9e2" no_wrapper=True %}

--- a/version_control/Codurance_September2020/modules/Newsletter Exit Popup.module/module.js
+++ b/version_control/Codurance_September2020/modules/Newsletter Exit Popup.module/module.js
@@ -27,7 +27,13 @@ const potentiallyLeavingPage = e => {
 }
 
 const setCookie = (key, value) => {
-  const expiry = 60 * 60 * 24 * 7;
+  const 
+    seconds = 60,
+    minutes = 60, 
+    hours = 24,
+    days = 90;
+
+  const expiry = seconds * minutes * hours * days;
   document.cookie = `${key}=${value}; path=/; max-age=${expiry}`;
 }
 

--- a/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/fields.json
@@ -1,12 +1,1 @@
-[ {
-  "id" : "34634bc3-9cd2-40be-a219-19d9b69414e0",
-  "name" : "sign_up_form",
-  "label" : "Sign Up Form",
-  "required" : true,
-  "locked" : false,
-  "type" : "form",
-  "default" : {
-    "response_type" : "inline",
-    "message" : "Thanks for submitting the form."
-  }
-} ]
+[ ]

--- a/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/fields.json
@@ -9,14 +9,4 @@
     "response_type" : "inline",
     "message" : "Thanks for submitting the form."
   }
-}, {
-  "id" : "22156426-5d5b-7fd3-b5f9-6ed2be26a016",
-  "name" : "language",
-  "label" : "language",
-  "required" : false,
-  "locked" : false,
-  "validation_regex" : "",
-  "allow_new_line" : false,
-  "show_emoji_picker" : false,
-  "type" : "text"
 } ]

--- a/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/module.html
+++ b/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/module.html
@@ -17,8 +17,6 @@
         <p class="newsletter-footer-form__info hidden" data-newsletter-sign-up-success>{{ copy.success.text }}</p>
         <span data-newsletter-sign-up-pending>{% form "email_form" form_to_use={{copy.form_id}} %}</span>
       </div>
-      <div class="newsletter-footer-form__image newsletter-footer-form__image--pending" data-newsletter-sign-up-pending></div>
-      <div class="newsletter-footer-form__image newsletter-footer-form__image--success hidden" data-newsletter-sign-up-success></div>
     </div>
 </section>
 

--- a/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/module.html
+++ b/version_control/Codurance_September2020/modules/Newsletter Footer Form.module/module.html
@@ -1,12 +1,8 @@
 {{ require_css(get_asset_url("../../css/newsletter-form.css")) }}
 {{ require_css(get_asset_url("../../css/modules/newsletter-footer-form.css")) }}
 
-
-{% set language = module.language %}
-{% set spanish = 'es' %}
-{% set english = 'en' %}
 {% import '../../config/config.html' as config %}
-{% if language == spanish %}
+{% if locale == "es" %}
   {% set copy = config.newsletter_cta.es %}
 {% else %}
   {% set copy = config.newsletter_cta.en %}

--- a/version_control/Codurance_September2020/templates/blog-post.html
+++ b/version_control/Codurance_September2020/templates/blog-post.html
@@ -4,16 +4,16 @@ isAvailableForNewContent: true
 label: Blog Post
 -->
 {% import '../snippets/button-snippets.html' as snippets %}
+
 {% import '../config/config.html' as config %}
 
-{% extends "./layouts/base.html" %}
+{% set newsletter_copy = config.newsletter_cta.en %}
 
-{% set path = request.path|truncate(3, true, '') %}
-{% if path is string_containing 'es' %}
-  {% set site_language = 'es'  %}
-{% else %}
-  {% set site_language = 'en' %}
+{% if locale == "es" %}
+  {% set newsletter_copy = config.newsletter_cta.es %}
 {% endif %}
+
+{% extends "./layouts/base.html" %}
 
 <head>
   <meta charset="utf-8">
@@ -190,12 +190,6 @@ label: Blog Post
       {% module "blog-recruitment-banner" path="../modules/Blog Post Banner Recruitment", label="CTA recruitment banner" no_wrapper=True %}
     </section>
   {% else %}
-    {% set newsletter_copy = config.newsletter_cta.en %}
-
-    {% if locale == "es" %}
-      {% set newsletter_copy = config.newsletter_cta.es %}
-    {% endif %}
-
     {% module 'newsletter_form_card'
       path='../modules/Newsletter-Form-Card.module',
       label="Newsletter Form card", 
@@ -291,17 +285,19 @@ label: Blog Post
     </div>
   </section>
 
-  {% module
-    "newsletter_footer_form"
-    path="../modules/Newsletter Footer Form.module"
-    label="Newsletter footer form", no_wrapper=True
+  {% module "newsletter_footer_form",
+    path="../modules/Newsletter Footer Form.module",
+    label="Newsletter footer form", 
+    no_wrapper=True
   %}
 
-    {% module
-      "newsletter_exit_popup"
-      path="../modules/Newsletter Exit Popup.module"
-      label="Newsletter exit popup", language='{{site_language}}', no_wrapper=True
-    %}
+  {% module "newsletter_exit_popup"
+    path="../modules/Newsletter Exit Popup.module",
+    label="Newsletter exit popup", 
+    language='{{ locale }}', 
+    no_wrapper=True
+  %}
+
   <script>
     var cookieIframeContainers = document.getElementsByClassName(
       'js-iframe-container'

--- a/version_control/Codurance_September2020/templates/blog-post.html
+++ b/version_control/Codurance_September2020/templates/blog-post.html
@@ -4,6 +4,7 @@ isAvailableForNewContent: true
 label: Blog Post
 -->
 {% import '../snippets/button-snippets.html' as snippets %}
+{% import '../config/config.html' as config %}
 
 {% extends "./layouts/base.html" %}
 
@@ -176,10 +177,35 @@ label: Blog Post
     </div>
   </section>
 
-  <section class="blog-recruitment-banner blog-max-width">
-    {% module "blog-recruitment-banner" path="../modules/Blog Post Banner Recruitment", label="CTA recruitment banner" no_wrapper=True %}
-  </section>
+  {% choice "CTA_or_newsletter_form" 
+    label='Choose between CTA banner and Newsletter form', 
+    value='CTA', 
+    choices='CTA, Newsletter-Form', 
+    no_wrapper=True, 
+    export_to_template_context=True 
+  %}
 
+  {% if widget_data.CTA_or_newsletter_form.value == "CTA" %}
+    <section class="blog-recruitment-banner blog-max-width">
+      {% module "blog-recruitment-banner" path="../modules/Blog Post Banner Recruitment", label="CTA recruitment banner" no_wrapper=True %}
+    </section>
+  {% else %}
+    {% set newsletter_copy = config.newsletter_cta.en %}
+
+    {% if locale == "es" %}
+      {% set newsletter_copy = config.newsletter_cta.es %}
+    {% endif %}
+
+    {% module 'newsletter_form_card'
+      path='../modules/Newsletter-Form-Card.module',
+      label="Newsletter Form card", 
+      no_wrapper=True,
+      title="{{ newsletter_copy.pending.header }}",
+      subtitle="{{ newsletter_copy.pending.text }}",
+      newsletter_form={ form_id: "{{ newsletter_copy.form_id }}" }
+    %}
+  {% endif %}
+  
   <section class="related-blog-section">
     <div class="related-blog-section__inner page-center">
       <h2 class="related-blog-section__title">
@@ -200,6 +226,7 @@ label: Blog Post
           </div>
         {% endif %}
       </div>
+
       <div class="row">
         {% if content.topic_list %} {% set max_posts = 3 %} {% set post_list = []
         %} {% for topic in content.topic_list %} {% set post_list = post_list +
@@ -263,11 +290,12 @@ label: Blog Post
       </div>
     </div>
   </section>
-    {% module
-      "newsletter_footer_form"
-      path="../modules/Newsletter Footer Form.module"
-      label="Newsletter footer form", no_wrapper=True
-    %}
+
+  {% module
+    "newsletter_footer_form"
+    path="../modules/Newsletter Footer Form.module"
+    label="Newsletter footer form", no_wrapper=True
+  %}
 
     {% module
       "newsletter_exit_popup"

--- a/version_control/Codurance_September2020/templates/blog-post.html
+++ b/version_control/Codurance_September2020/templates/blog-post.html
@@ -266,7 +266,7 @@ label: Blog Post
     {% module
       "newsletter_footer_form"
       path="../modules/Newsletter Footer Form.module"
-      label="Newsletter footer form", language='{{site_language}}', no_wrapper=True
+      label="Newsletter footer form", no_wrapper=True
     %}
 
     {% module

--- a/version_control/Codurance_September2020/templates/blog-post.html
+++ b/version_control/Codurance_September2020/templates/blog-post.html
@@ -167,16 +167,7 @@ label: Blog Post
   </section>
   <section class="blog-content blog-max-width">
     <div class="blog-content__inner">
-      {% set sections = content.post_body|split('<!--more-->', 2) %}
-      {{ sections[0] }}
-      {% if site_language == 'en' %}
-        {% module
-          "newsletter_inline_form"
-          path="../modules/Newsletter Inline Form.module"
-          label="Newsletter inline form", language='{{site_language}}', no_wrapper=True
-        %}
-      {% endif %}
-      {{ sections[1] }}
+      {{ content.post_body }}
     </div>
     {% module "continue_in_english_blog_banner" path="../modules/Continue in English Blog Banner", label="Include link to EN version?" %}
     <div class="blog-comments">


### PR DESCRIPTION
Blog posts improvements: Refactor pre-existing newsletter signup modules and implement feature to let Hubspot users to choose to display either a newsletter form or a CTA block at the end of the content.

- Hubspot users will be able to choose which module to show at the end of the content between the Newsletter-Form-Card (previously the Newsletter Inline Form) and the Blog Post Banner Recruitment modules
- Redesign Newsletter Footer Form module, removing the image and simplifying the language display method
- Simplify Blog Post Banner Recruitment module, removing unused features
- Augment the cookie from the Newsletter Form Popup module expiry date from 7 to 90 days