### PR TITLE
Set up the codebase to create Katalyst ES

### DIFF
--- a/version_control/Codurance_September2020/modules/filtered-katas.module/fields.json
+++ b/version_control/Codurance_September2020/modules/filtered-katas.module/fields.json
@@ -1,1 +1,10 @@
-[ ]
+[ {
+  "id" : "24da89bc-f9ce-10c8-fbac-ddb6c43bf64f",
+  "name" : "katalyst_blog",
+  "display_width" : null,
+  "label" : "Katalyst Blog",
+  "required" : false,
+  "locked" : false,
+  "placeholder" : "Select the Katayst blog",
+  "type" : "blog"
+} ]

--- a/version_control/Codurance_September2020/modules/filtered-katas.module/module.html
+++ b/version_control/Codurance_September2020/modules/filtered-katas.module/module.html
@@ -1,9 +1,11 @@
 {{ require_css(get_asset_url("../../css/modules/filtered-katas.css")) }}
 
-{% set blogPosts = contents %}
+{% set katalystBlog = module.katalyst_blog %}
+
+{% set blogPosts = blog_recent_posts(katalystBlog, 200) %}
 
 {% set difficulties = ["Novice", "Beginner", "Competent", "Expert"] %}
-{% set topicObjects = blog_tags("default", 100) %}
+{% set topicObjects = blog_tags(katalystBlog, 100) %}
 {% set topics = [] %}
 {% for topic in topicObjects %}
   {% if !difficulties.contains(topic.name) %}


### PR DESCRIPTION
A new field has been added to the katas module to be able to choose the Katalyst blog to show on the corresponding blog listing pages.