### PR TITLE
Enhancement/upcoming-events-language

### DIFF
--- a/version_control/Codurance_September2020/modules/Recent-Events-Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Recent-Events-Listing.module/module.html
@@ -4,7 +4,14 @@
 
 {% if module.hubdb_table %} 
   {% set previousEventsFilter = "&orderBy=-date&limit=4" %}
-  {% set previousEvents = hubdb_table_rows(module.hubdb_table, previousEventsFilter) %}
+  {% set isEventEnglish = ("&language=English") %}
+
+  {% if locale == "en" %}
+    {% set previousEvents = hubdb_table_rows(module.hubdb_table, previousEventsFilter + isEventEnglish) %}
+  {% else %}
+    {% set previousEvents = hubdb_table_rows(module.hubdb_table, previousEventsFilter) %}
+  {%endif%}
+
 
 <div
   class="card-slider__event-inner responsive-page-width lateral-spacing"

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -4,7 +4,13 @@
 
 {% if module.hubdb_table %}
   {% set upcomingEventsFilter = ("&orderBy=datetime" + "&datetime__gt=" + local_dt|unixtimestamp + "&limit=12") %}
-  {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
+  {% set isEventEnglish = ("&language=English") %}
+  
+   {% if locale == "en" %}
+      {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter + isEventEnglish) %}
+    {% else %}
+       {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
+   {% endif %} 
 
   {% if upcomingEvents|length > 0 %}
     <div
@@ -13,6 +19,7 @@
     >
       <div class="card-slider__header-wrapper">
         <h2 class="card-slider__heading responsive-page-width">
+        
           {{ module.heading }}
         </h2>
         <div class="card-slider__nav-button-wrapper">


### PR DESCRIPTION
Until now, we had mixed languages on the events page. We decided to move into showing the content depending on the domain name. On the English site there will be only events hold in that language, on the other hand, if the site is in Spanish the user will see all events in both languages.

To make this work, we had to create a language column on the upcoming events DDBB table.
