### PR TITLE
Insights overview hotfix

### DIFF
--- a/version_control/Codurance_September2020/css/modules/editors-pick.css
+++ b/version_control/Codurance_September2020/css/modules/editors-pick.css
@@ -13,22 +13,24 @@
 }
 
 .cm-editors-pick__items {
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 1.5rem;
     margin-bottom: 1.5rem;
 }
 
 .cm-editors-pick__big_items {
-    display: flex;
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 1.5rem;
+    grid-column: 1 / span 2;
 }
 
 .cm-editors-pick__small_items {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    grid-column: 3;
 }
 
 .cm-editors-pick__title-big {
@@ -76,7 +78,11 @@
 
 {% call utils.small() %}
     .cm-editors-pick__items, .cm-editors-pick__big_items, .cm-editors-pick__small_items {
-        flex-direction: column;
+        grid-template-columns: 1fr;
+    }
+
+    .cm-editors-pick__big_items, .cm-editors-pick__small_items {
+        grid-column: 1;
     }
 
     .cm-editors-pick__image {
@@ -98,16 +104,18 @@
 
 {% call utils.medium() %}
     .cm-editors-pick__items {
-        flex-direction: column;
+        grid-template-columns: 1fr;
         margin-bottom: 2.5rem;
     }
 
     .cm-editors-pick__big_items {
-        flex-direction: row;
+        grid-template-columns: 1fr 1fr;
+        grid-column: 1;
     }
 
     .cm-editors-pick__small_items {
-        flex-direction: column;
+        grid-template-columns: 1fr;
+        grid-column: 1;
     }
 {% endcall %}
 

--- a/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
+++ b/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
@@ -21,7 +21,9 @@
         <article class="cm-editors-pick__item">
           {% if loop.index <= 2 %}
             <figure class="cm-editors-pick__image">
-              <img src='{% image_src src="{{ featured_post.featured_image }}" no_wrapper=True %}' alt="{{ featured_post.title }}">
+              {% if featured_post.featured_image %}
+                <img src='{% image_src src="{{ featured_post.featured_image }}" no_wrapper=True %}' alt="{{ featured_post.title }}">
+              {% endif %}
             </figure>      
           {% endif %}
           <h3 class="cm-editors-pick__title-big">

--- a/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
+++ b/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
@@ -26,7 +26,7 @@
             {{ featured_post.name }}
           </h3>
           <p class="cm-editors-pick__excerpt-big">
-            {{ featured_post.postBody|striptags|truncate(130, false) }}
+            {{ featured_post.meta_description }}
             {{
               snippets.text_cta_right_arrow(
                 url=featured_post.absolute_url,
@@ -48,7 +48,7 @@
             {{ other_post.name }}
           </h3>
           <p class="cm-editors-pick__excerpt-small">
-            {{ other_post.postBody|striptags|truncate(130, false) }}
+            {{ other_post.meta_description }}
             {{
               snippets.text_cta_right_arrow(
                 url=other_post.absolute_url,

--- a/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
+++ b/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
@@ -16,6 +16,8 @@
     <div class="cm-editors-pick__big_items">
       {% for content_id in featured_posts %}
         {% set featured_post = content_by_id(content_id) %}
+        {% set contentType = featured_post.CMSContentType.valueDescriptor.name %}
+        {% set title = contentType == "STANDARD_PAGE" ? featured_post.title : featured_post.name %}
         <article class="cm-editors-pick__item">
           {% if loop.index <= 2 %}
             <figure class="cm-editors-pick__image">
@@ -23,7 +25,7 @@
             </figure>      
           {% endif %}
           <h3 class="cm-editors-pick__title-big">
-            {{ featured_post.name }}
+            {{ title }}
           </h3>
           <p class="cm-editors-pick__excerpt-big">
             {{ featured_post.meta_description }}
@@ -43,9 +45,11 @@
     <div class="cm-editors-pick__small_items">
       {% for content_id in other_posts %}
         {% set other_post = content_by_id(content_id) %}
+        {% set contentType = other_post.CMSContentType.valueDescriptor.name %}
+        {% set title = contentType == "STANDARD_PAGE" ? other_post.title : other_post.name %}
         <article class="cm-editors-pick__item">
           <h3 class="cm-editors-pick__title-small">
-            {{ other_post.name }}
+            {{ title }}
           </h3>
           <p class="cm-editors-pick__excerpt-small">
             {{ other_post.meta_description }}

--- a/version_control/Codurance_September2020/modules/Recent-posts-V2.module/module.html
+++ b/version_control/Codurance_September2020/modules/Recent-posts-V2.module/module.html
@@ -1,4 +1,5 @@
 {% import '../../snippets/button-snippets.html' as snippets %}
+{% import '../../css/utils/utils.css' as utils %}
 
 {{ require_css(get_asset_url("../../css/modules/recent-posts-v2.css")) }}
 
@@ -7,9 +8,9 @@
   <div class="cm-recent-post__group">
     {% for post in recent_posts %}
       <div class="cm-recent-post__item">
-        {% if post.featured_image %}
-          <div class="cm-recent-image-wrapper" style="background-image:url({{ post.featured_image }})"></div>
-        {% endif %}
+        {#% set style = post.featured_image ? "background-image:url({{ post.featured_image }})" : "background-color: {{ theme.global_colors.secondary_color.color }}" %#}
+        {% set style = post.featured_image ? "background-image:url({{ post.featured_image }})" : "{{ utils.tango_to_white() }}" %}
+        <div class="cm-recent-image-wrapper" style="{{ style }}"></div>
         <div class="cm-recent-post__inner">
           <div class="cm-recent-post__info-wrapper">
             <small class="cm-recent-post__meta-info">{{ post.publish_date_local_time|datetimeformat("%d %b %Y") }} - {{ post.blog_post_author.display_name }}</small>

--- a/version_control/Codurance_September2020/modules/Recent-posts-V2.module/module.html
+++ b/version_control/Codurance_September2020/modules/Recent-posts-V2.module/module.html
@@ -8,7 +8,6 @@
   <div class="cm-recent-post__group">
     {% for post in recent_posts %}
       <div class="cm-recent-post__item">
-        {#% set style = post.featured_image ? "background-image:url({{ post.featured_image }})" : "background-color: {{ theme.global_colors.secondary_color.color }}" %#}
         {% set style = post.featured_image ? "background-image:url({{ post.featured_image }})" : "{{ utils.tango_to_white() }}" %}
         <div class="cm-recent-image-wrapper" style="{{ style }}"></div>
         <div class="cm-recent-post__inner">


### PR DESCRIPTION
Hot fixes for the following issues ...

- editor's pick column sizing inconsistent (changed to use css-grid, instead of flex-box)
- editor's pick featured post image sizes differ (as above)
- title using internal name for pages (change to use title instead of name for pages)
- missing subtitle for pages (changed to use meta_description rather than first 150 characters of postBody)
- broken image link appearing when page/blog post has no featured image
- recent-posts-v2 - when no featured image, text appears at top, which results in misalignment of text when there is a mix of recents posts some with featured images, some without (use tango-to-white gradient instead of image)