### PR TITLE
Hotfix/insights overview page

### DIFF
--- a/version_control/Codurance_September2020/css/modules/editors-pick.css
+++ b/version_control/Codurance_September2020/css/modules/editors-pick.css
@@ -107,6 +107,15 @@
 {% endcall %}
 
 {% call utils.small() %}
+       .cm-editors-pick__items {
+        margin-bottom: 1.5rem;
+    }
+
+    .cm-editors-pick__big_items, .cm-editors-pick__small_items {
+        display: grid;
+        gap: 1.5rem;
+    }
+
     .cm-editors-pick__image {
         margin-bottom: 0.5rem;
     }

--- a/version_control/Codurance_September2020/css/modules/editors-pick.css
+++ b/version_control/Codurance_September2020/css/modules/editors-pick.css
@@ -12,27 +12,6 @@
     padding-inline: 2rem;
 }
 
-.cm-editors-pick__items {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.cm-editors-pick__big_items {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
-    grid-column: 1 / span 2;
-}
-
-.cm-editors-pick__small_items {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    grid-column: 3;
-}
-
 .cm-editors-pick__title-big {
     font-size: var(--base-font-size);
     font-weight: var(--heavy-font-weight);
@@ -76,32 +55,40 @@
     border-radius: 10px;
 }
 
-{% call utils.small() %}
-    .cm-editors-pick__items, .cm-editors-pick__big_items, .cm-editors-pick__small_items {
-        grid-template-columns: 1fr;
-    }
-
-    .cm-editors-pick__big_items, .cm-editors-pick__small_items {
-        grid-column: 1;
-    }
-
-    .cm-editors-pick__image {
-        margin-bottom: 0.5rem;
-    }
-
+{% call utils.medium_large_and_extra_large() %}
+    .cm-editors-pick__items {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 1.5rem;
+        margin-bottom: 1.5rem;
+        }
+    
+    .cm-editors-pick__big_items {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1.5rem;
+        grid-column: 1 / span 2;
+        }
+        
+    .cm-editors-pick__small_items {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        grid-column: 3;
+        }
     .cm-editors-pick__image img {
-        height: 60%;
+        position: absolute;
         width: 100%;
-    }
+        height: 100%;
+        }
+                
+    .cm-editors-pick__image::after {
+        content: "";
+        display: block;
+        padding-bottom: 100%;
+        }
 {% endcall %}
-
-{% call small_landscape() %}
-    .cm-editors-pick__image img {
-        height: 100px;
-        width: 100%;
-    }
-{% endcall %}
-
+                    
 {% call utils.medium() %}
     .cm-editors-pick__items {
         grid-template-columns: 1fr;
@@ -119,16 +106,20 @@
     }
 {% endcall %}
 
-{% call utils.medium_large_and_extra_large() %}
-    .cm-editors-pick__image img {
-        position: absolute;
-        width: 100%;
-        height: 100%;
+{% call utils.small() %}
+    .cm-editors-pick__image {
+        margin-bottom: 0.5rem;
     }
 
-    .cm-editors-pick__image::after {
-        content: "";
-        display: block;
-        padding-bottom: 100%;
+    .cm-editors-pick__image img {
+        height: 60%;
+        width: 100%;
+    }
+{% endcall %}
+
+{% call small_landscape() %}
+    .cm-editors-pick__image img {
+        height: 100px;
+        width: 100%;
     }
 {% endcall %}

--- a/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
+++ b/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
@@ -18,15 +18,13 @@
       {% for content_id in featured_posts %}
         {% set featured_post = content_by_id(content_id) %}
         {% set contentType = featured_post.CMSContentType.valueDescriptor.name %}
-        {% set title = contentType == "STANDARD_PAGE" ? featured_post.title : featured_post.name %}
+        {% set title = contentType == ("STANDARD_PAGE" or "LANDING_PAGE") ? featured_post.title : featured_post.name %}
         <article class="cm-editors-pick__item">
-          {% if loop.index <= 2 %}
             <figure class="cm-editors-pick__image">
               {% if featured_post.featured_image %}
                 <img src='{% image_src src="{{ featured_post.featured_image }}" no_wrapper=True %}' alt="{{ featured_post.title }}">
               {% endif %}
             </figure>      
-          {% endif %}
           <h3 class="cm-editors-pick__title-big">
             {{ title }}
           </h3>

--- a/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
+++ b/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
@@ -17,8 +17,6 @@
     <div class="cm-editors-pick__big_items">
       {% for content_id in featured_posts %}
         {% set featured_post = content_by_id(content_id) %}
-        {% set contentType = featured_post.CMSContentType.valueDescriptor.name %}
-        {% set title = contentType == ("STANDARD_PAGE" or "LANDING_PAGE") ? featured_post.title : featured_post.name %}
         <article class="cm-editors-pick__item">
             <figure class="cm-editors-pick__image">
               {% if featured_post.featured_image %}
@@ -26,7 +24,7 @@
               {% endif %}
             </figure>      
           <h3 class="cm-editors-pick__title-big">
-            {{ title }}
+            {{ description_snippets.title(featured_post) }}
           </h3>
           <p class="cm-editors-pick__excerpt-big">
             {{ 
@@ -51,11 +49,9 @@
     <div class="cm-editors-pick__small_items">
       {% for content_id in other_posts %}
         {% set other_post = content_by_id(content_id) %}
-        {% set contentType = other_post.CMSContentType.valueDescriptor.name %}
-        {% set title = contentType == "STANDARD_PAGE" ? other_post.title : other_post.name %}
         <article class="cm-editors-pick__item">
           <h3 class="cm-editors-pick__title-small">
-            {{ title }}
+            {{ description_snippets.title(other_post) }}
           </h3>
           <p class="cm-editors-pick__excerpt-small">
             {{ 

--- a/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
+++ b/version_control/Codurance_September2020/modules/Editors-Pick.module/module.html
@@ -1,4 +1,5 @@
-{% import '../../snippets/button-snippets.html' as snippets %}
+{% import '../../snippets/button-snippets.html' as button_snippets %}
+{% import '../../snippets/insights-overview-snippets.html' as description_snippets %}
 
 {{ require_css(get_asset_url("../../css/modules/editors-pick.css")) }}
 
@@ -30,9 +31,14 @@
             {{ title }}
           </h3>
           <p class="cm-editors-pick__excerpt-big">
-            {{ featured_post.meta_description }}
+            {{ 
+              description_snippets.truncate_description(
+                text=featured_post.meta_description,
+                character_limit=150
+              )
+            }}
             {{
-              snippets.text_cta_right_arrow(
+              button_snippets.text_cta_right_arrow(
                 url=featured_post.absolute_url,
                 text="{{ module.item_button_text }}",
                 classnames="cm-editors-pick__link",
@@ -54,9 +60,14 @@
             {{ title }}
           </h3>
           <p class="cm-editors-pick__excerpt-small">
-            {{ other_post.meta_description }}
+            {{ 
+              description_snippets.truncate_description(
+                text=other_post.meta_description,
+                character_limit=150
+              )
+            }}
             {{
-              snippets.text_cta_right_arrow(
+              button_snippets.text_cta_right_arrow(
                 url=other_post.absolute_url,
                 classnames="cm-editors-pick__link cm-editors-pick__link-small",
                 aria_label_text="{{ module.aria_label_prefix_text~other_post.name 
@@ -69,7 +80,7 @@
     </div>
   </section>
   {{
-    snippets.button_primary(
+    button_snippets.button_primary(
       url=blog_url,
       text="{{ module.button_text }}",
       aria_label_text="{{ module.button_text }}"

--- a/version_control/Codurance_September2020/snippets/insights-overview-snippets.html
+++ b/version_control/Codurance_September2020/snippets/insights-overview-snippets.html
@@ -1,0 +1,7 @@
+<!--
+  templateType: "none"
+  isAvailableForNewContent: false
+-->
+{% macro truncate_description(text, character_limit) %}
+{{ text|safe|striptags|truncatehtml(character_limit, ' ...' , false) }}
+{% endmacro %}

--- a/version_control/Codurance_September2020/snippets/insights-overview-snippets.html
+++ b/version_control/Codurance_September2020/snippets/insights-overview-snippets.html
@@ -5,3 +5,9 @@
 {% macro truncate_description(text, character_limit) %}
 {{ text|safe|striptags|truncatehtml(character_limit, ' ...' , false) }}
 {% endmacro %}
+
+{% macro title(post) %}
+{% set contentType = post.CMSContentType %}
+{% set title = contentType == "BLOG_POST" ? post.name : post.title %}
+{{ title }}
+{% endmacro %}


### PR DESCRIPTION
Hot fixes for the following issues ...

- refactor of grid styling of editor's pick module for different breakpoints. (previous grid column styling for mobile screen size have now been removed after grid styles applied to tablet and desktop screen sizes)


- truncation of editor's pick item descriptions with `truncate_description` macro - limited to 150 characters (previously no limit was added because of hubspot 155 character meta description limit, however this made item descriptions look less harmonious)

- remove conditional loop check for big editor pick items (no longer necessary with previous addition of two separate loops for big and small editor pick items)

- render page title of landing page items with `title` macro (previously landing pages e.g. case study templates were rendered with internal page names)

