### PR TITLE
Hotfix/insights-overview/fireside-chats

### DIFF
--- a/version_control/Codurance_September2020/css/modules/fireside-chat-videos.css
+++ b/version_control/Codurance_September2020/css/modules/fireside-chat-videos.css
@@ -33,8 +33,12 @@
 
 {% call utils.medium_large_and_extra_large() %}
     .fireside-chat-videos {
-        columns: 2;
-        column-gap: 2em;
+        display: flex;
+        gap: 2em;
+    }
+
+    .fireside-chat-video {
+        flex-basis: 100%;
     }
 {% endcall %}
 

--- a/version_control/Codurance_September2020/css/templates/insights-overview.css
+++ b/version_control/Codurance_September2020/css/templates/insights-overview.css
@@ -81,13 +81,12 @@
     {{ utils.eames() }}
     max-width: var(--content-max-width);
     margin-inline: auto;
-    margin-bottom: var(--eames-margin);
+    margin-bottom: 2rem;
 }
 
 {% call utils.small() %}
     .fireside-chats-title {
         {{ utils.dudler() }}
-        margin-bottom: var(--dudler-margin);
     }
 {% endcall %}
 


### PR DESCRIPTION
- When the video title was too long the time moved to the next column
- Adjust margin-bottom of the section title