### PR TITLE
Display  events shown on the EN and ES site

### DIFF
--- a/version_control/Codurance_September2020/modules/Simple-Card.module/module.html
+++ b/version_control/Codurance_September2020/modules/Simple-Card.module/module.html
@@ -2,34 +2,44 @@
 {% import '../../snippets/button-snippets.html' as snippets %}
 {{ require_css(get_asset_url("../css/modules/simple-card.css")) }}    
 
-{% set latest_events = hubdb_table_rows(module.hubdb, "&orderBy=-datetime&limit=3") %}
+{% if module.hubdb %}
+    
+    {% set upcomingEventsFilter = ("&orderBy=datetime" + "&datetime__gt=" + local_dt|unixtimestamp + "&limit=3") %}
+    {% set isEventEnglish = ("&language=English") %}
+
+    {% if locale == "en" %}
+        {% set latest_events = hubdb_table_rows(module.hubdb, upcomingEventsFilter + isEventEnglish) %}
+    {% else %}
+        {% set latest_events = hubdb_table_rows(module.hubdb, upcomingEventsFilter) %}
+    {% endif %} 
 
 
-<div class="card-container">
-    {% for event in latest_events %}
+    <div class="card-container">
+        {% for event in latest_events %}
 
-        {% set formated_date = event.datetime | format_datetime('d MMM yyyy | HH:mm') %}
-        {% if locale == 'es' %}
-            {% set formated_date = event.datetime | format_datetime('d MMM yyyy | HH:mm', 'Europe/Madrid') %}
-        {% endif %} 
+            {% set formated_date = event.datetime | format_datetime('d MMM yyyy | HH:mm') %}
+            {% if locale == 'es' %}
+                {% set formated_date = event.datetime | format_datetime('d MMM yyyy | HH:mm', 'Europe/Madrid') %}
+            {% endif %} 
 
-        <article class="card">
-            <img class="card__img" src="{{ resize_image_url(event.thumbnail.url, 400) }}" 
-                alt="" 
-                width="400"
-                height="281"
-                loading="lazy" >
+            <article class="card">
+                <img class="card__img" src="{{ resize_image_url(event.thumbnail.url, 400) }}" 
+                    alt="" 
+                    width="400"
+                    height="281"
+                    loading="lazy" >
 
-            <div class="card__info">
-                <time>{{ formated_date }}</time>
-                <h3>{{ event.name }}</h3>
-                {{ snippets.text_cta_right_arrow(
-                    url=event.link,
-                    target="_blank",
-                    text="{{ module.card_link_text }}"
-                ) }}
-            </div>
-        </article>
-    {% endfor %}
-</div>
+                <div class="card__info">
+                    <time datetime={{ event.datetime }} >{{ formated_date }}</time>
+                    <h3>{{ event.name }}</h3>
+                    {{ snippets.text_cta_right_arrow(
+                        url=event.link,
+                        target="_blank",
+                        text="{{ module.card_link_text }}"
+                    ) }}
+                </div>
+            </article>
+        {% endfor %}
+    </div>
+{% endif %}
 


### PR DESCRIPTION
There was an issue related to the events that were displaying. Now on the EN site only English events will show. On the ES site, both languages will appear.