### PR TITLE
Fix/our-people-loading-assets

### DIFF
--- a/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
@@ -20,7 +20,12 @@
         <div class="custom-our-people__card-inner" data-modal-target="#team-{{ loop.index }}">
           {% if row.image.url %}
             <img class="custom-our-people__profile-image" 
-              src="{{ resize_image_url(row.image.url, 300) }}"
+              srcset="
+                {{ resize_image_url(row.image.url, 180) }} 180w,
+                {{ resize_image_url(row.image.url, 300) }} 500w"
+              sizes="
+                (max-width: 400px) 180px,
+                500px"
               width="300" height="300" loading="lazy" 
               alt="{{ row.name }}" >
           {% endif %}

--- a/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
@@ -19,7 +19,7 @@
       <article class="custom-our-people__card  {% if row.leadership_board %}leadership{% endif %}">
         <div class="custom-our-people__card-inner" data-modal-target="#team-{{ loop.index }}">
           {% if row.image.url %}
-            <img class="custom-our-people__profile-image" src="{{ row.image.url }}" alt="{{ row.name }}">
+            <img class="custom-our-people__profile-image" src="{{ resize_image_url(row.image.url, 400) }}" alt="{{ row.name }}">
           {% endif %}
           <div class="custom-our-people__info">
             {% if row.name %}

--- a/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
@@ -22,10 +22,10 @@
             <img class="custom-our-people__profile-image" 
               srcset="
                 {{ resize_image_url(row.image.url, 180) }} 180w,
-                {{ resize_image_url(row.image.url, 300) }} 500w"
+                {{ resize_image_url(row.image.url, 300) }} 300w"
               sizes="
-                (max-width: 400px) 180px,
-                500px"
+                (max-width: 425px) 180px,
+                300px"
               width="300" height="300" loading="lazy" 
               alt="{{ row.name }}" >
           {% endif %}

--- a/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Our-People-Listing.module/module.html
@@ -19,7 +19,10 @@
       <article class="custom-our-people__card  {% if row.leadership_board %}leadership{% endif %}">
         <div class="custom-our-people__card-inner" data-modal-target="#team-{{ loop.index }}">
           {% if row.image.url %}
-            <img class="custom-our-people__profile-image" src="{{ resize_image_url(row.image.url, 400) }}" alt="{{ row.name }}">
+            <img class="custom-our-people__profile-image" 
+              src="{{ resize_image_url(row.image.url, 300) }}"
+              width="300" height="300" loading="lazy" 
+              alt="{{ row.name }}" >
           {% endif %}
           <div class="custom-our-people__info">
             {% if row.name %}


### PR DESCRIPTION
We had currently a long listing of people working for us, thus performance issues came along due different image sizes.

I've added:
* A srcset specifically for mobile to improve loading times and LCP
* A resizing hubspot method to set a default value without thinking on how users upload their images
* A set width and height, so we can lazy load images