### PR TITLE
Style: create a default spacing for mobile and tablets

### DIFF
--- a/version_control/Codurance_September2020/css/pages/case-study-template-v2.css
+++ b/version_control/Codurance_September2020/css/pages/case-study-template-v2.css
@@ -142,6 +142,14 @@ body {
   {{ utils.base() }}
 }
 
+
+
+{% call utils.small_and_medium() %}
+  .dnd-section {
+    padding-inline: var(--space-3);
+  }
+{% endcall%}  
+
 {% call utils.small() %}
   
   .dnd-section h2 {


### PR DESCRIPTION
We found that by default there wasn't a margin on small devices on the case study template page.