### PR TITLE
feature: show only events in Spanish on the ES site

### DIFF
--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -4,13 +4,14 @@
 
 {% if module.hubdb_table %}
   {% set upcomingEventsFilter = ("&orderBy=datetime" + "&datetime__gt=" + local_dt|unixtimestamp + "&limit=12") %}
-  {% set isEventEnglish = ("&language=English") %}
+  {% set eventsInEnglish = ("&language=English") %}
+  {% set eventsInSpanish = ("&language=Spanish") %}
+
+  {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter + eventsInEnglish) %}
   
-   {% if locale == "en" %}
-      {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter + isEventEnglish) %}
-    {% else %}
-       {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter) %}
-   {% endif %} 
+  {% if locale == "es" %}
+    {% set upcomingEvents = hubdb_table_rows(module.hubdb_table, upcomingEventsFilter + eventsInSpanish) %}
+  {% endif %}
 
   {% if upcomingEvents|length > 0 %}
     <div


### PR DESCRIPTION
The Spanish marketing team requested having only Spanish events on the site when selecting the language. For further information please [check the request](https://codurance-unit.monday.com/boards/1582824572/pulses/4264382755)