### PR TITLE
Create a specific selector for all languages and hide it on mobile

### DIFF
--- a/version_control/Codurance_September2020/modules/Utilities-Menu.module/module.html
+++ b/version_control/Codurance_September2020/modules/Utilities-Menu.module/module.html
@@ -42,7 +42,7 @@
 		{% if href %}
 		<li class="menu-item">
 			<a href="{{ href }}"
-				class="{{ module.link.text|split(' ')|join('-')|lower}} menu-link"
+				class="contact-us menu-link"
 				{% if module.link.settings.open_in_new_tab %}target="_blank"{% endif %}
 				{% if module.link.settings.rel %}rel="{{ module.link.settings.rel }}"{% endif %}
 				{{ isActiveNode(href) }}

--- a/version_control/Codurance_September2020/modules/Utilities-Menu.module/module.html
+++ b/version_control/Codurance_September2020/modules/Utilities-Menu.module/module.html
@@ -3,7 +3,7 @@
 {% macro isActiveNode(link) %}
 	{% set link_stripped = "/" + link | split('/', 3) | last %}
 	{% if request.path == link_stripped %}
-		{{ { "class": "active-item",
+		{{ { "class": "active-item contact-us menu-link",
 		"aria-current": "page"
 		} | xmlattr
 		}}


### PR DESCRIPTION
At the moment on mobile screens the contact us link was still showing at the top bar menu on ES and PT sites. This is the fix to it applying an specific css class for all languages