### PR TITLE
New template/service line/learning and development

### DIFF
--- a/version_control/Codurance_September2020/css/modules/course-cards.css
+++ b/version_control/Codurance_September2020/css/modules/course-cards.css
@@ -20,11 +20,12 @@
 .course-card__image {
   aspect-ratio: 16/9;
   object-fit: cover;
-  object-position: center;
+  object-position: top;
 }
     
 .course-content {
     padding: var(--space-4);
+    padding-top: var(--space-3);
 }
 
 .course-content h3 {
@@ -36,7 +37,7 @@
 }
 
 .course-content > p {
-    margin-top: var(--space-4);
+    margin-top: var(--space-2);
 }
 .course-info__instructor {
     display: flex;
@@ -56,7 +57,7 @@
 }
 
 .course-content .button-primary {
-    margin-top: var(--space-2);
+    margin-top: var(--space-3);
 }
 
 

--- a/version_control/Codurance_September2020/css/modules/course-cards.css
+++ b/version_control/Codurance_September2020/css/modules/course-cards.css
@@ -1,7 +1,15 @@
 {% import '../utils/utils.css' as utils %}
 
+.course-card-group {
+    --columns: auto-fit;
+    --gap: var(--space-2);
+    display: grid;
+    gap: var(--gap);
+    grid-template-columns: repeat(var(--columns), minmax(270px, 1fr))
+}
+
+
 .course-card {
-    max-width: 500px;
     margin-inline: auto;
     background-color: hsla(205, 39%, 17%, .8);
     {{ utils.card_border_radius() }}
@@ -9,7 +17,7 @@
     overflow: hidden;
 }
 
-.course-card img {
+.course-card__image {
   aspect-ratio: 16/9;
   object-fit: cover;
   object-position: center;
@@ -50,3 +58,37 @@
 .course-content .button-primary {
     margin-top: var(--space-2);
 }
+
+
+{% call utils.medium_large_and_extra_large() %}
+    .course-card-group {
+        --columns: 2;
+        --gap: var(--space-4);
+    }
+
+    .featured-card {
+        grid-column: 1 / span 2;
+        display: flex;
+    }
+
+    .featured-card img {
+        width: 45%
+    }
+
+    .featured-card .course-content {
+        max-width: 40%;
+        margin-inline: auto;
+        padding-top: var(--space-5);
+        padding-bottom: var(--space-5);
+    }
+
+    .featured-card .course-content h3 {
+        {{ utils.dudler() }}
+    }
+
+
+    .course-card:not(:first-child) .course-card__image {
+        /* cinemascope ratio */
+        aspect-ratio: 21 / 9;
+    }
+{% endcall %}

--- a/version_control/Codurance_September2020/css/modules/course-cards.css
+++ b/version_control/Codurance_September2020/css/modules/course-cards.css
@@ -1,0 +1,52 @@
+{% import '../utils/utils.css' as utils %}
+
+.course-card {
+    max-width: 500px;
+    margin-inline: auto;
+    background-color: hsla(205, 39%, 17%, .8);
+    {{ utils.card_border_radius() }}
+    {{ utils.card_shadow() }}
+    overflow: hidden;
+}
+
+.course-card img {
+  aspect-ratio: 16/9;
+  object-fit: cover;
+  object-position: center;
+}
+    
+.course-content {
+    padding: var(--space-4);
+}
+
+.course-content h3 {
+    {{ utils.freed() }}
+}
+
+.course-content p {
+    {{ utils.natus() }}
+}
+
+.course-content > p {
+    margin-top: var(--space-4);
+}
+.course-info__instructor {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+}
+
+.course-info__instructor img {
+    aspect-ratio: 1/1;
+    border-radius: 50%;
+    max-width: 50px;
+}
+
+.course-info__instructor p {
+    font-weight: var(--middle-font-weight);
+}
+
+.course-content .button-primary {
+    margin-top: var(--space-2);
+}

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -1,18 +1,39 @@
 {% import '../utils/utils.css' as utils %}
 
-  .banner-area {
-    color: white;
-  } 
+.banner-area {
+  color: white;
+} 
 
-  /* Overrides the default padding 0 */
-  .dnd-section {
-    padding-top: var(--space-7) !important;
-    padding-bottom: var(--space-7) !important;
-  }
+/* Overrides the default padding 0 */
+.dnd-section {
+  padding-top: var(--space-7) !important;
+  padding-bottom: var(--space-7) !important;
+}
 
-  .dnd-row:not(:first-child) {
-    margin-top: var(--space-7);
-  }
+.dnd-row:not(:first-child) {
+  margin-top: var(--space-7);
+}
+
+.banner-area .dnd-column > .dnd-row:first-child .text-and-image__container {
+  max-width: var(--content-max-width);
+}
+
+.banner-area .page-header.section-header {
+  max-width: var(--content-inner-max-width);
+}
+
+.banner-area .page-header.section-header h2 {
+  max-width: var(--eames-max-width);
+}
+
+.banner-area .page-header.section-header p {
+  max-width: var(--freed-max-width);
+}
+
+.banner-area .widget-type-header h2 {
+  max-width: var(--content-inner-max-width);
+  margin-inline: auto;
+}
 
 {% call utils.small() %}
   .banner-area .dnd-row {

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -87,18 +87,6 @@
 
 /* Katalyst section */
 
-.katalyst .page-header.section-header {
-   /* Overrides default margin bottom */
-  margin-bottom: revert !important;
-}
-
-
-.katalyst .section-header h2 {
-  {{ utils.dudler() }}
-  font-weight: var(--heavy-font-weight);
-  margin-bottom: var(--space-2);
-}
-
 .katalyst {
   --gap: var(--space-6);
   display: flex;
@@ -114,6 +102,21 @@
 
 .katalyst > * {
   flex: 1 1 calc(50% - var(--gap));
+}
+
+.katalyst .page-header.section-header {
+   /* Overrides default margin bottom */
+  margin-bottom: revert !important;
+}
+
+.katalyst .section-header h2 {
+  {{ utils.dudler() }}
+  font-weight: var(--heavy-font-weight);
+  margin-bottom: var(--space-2);
+}
+
+.katalyst div.custom-btn {
+  margin-top: var(--space-3);
 }
 
 .katalyst__video .oembed_container,

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -88,6 +88,7 @@
 /* Katalyst section */
 .katalyst .section-header h2 {
   {{ utils.dudler() }}
+  font-weight: var(--heavy-font-weight);
   margin-bottom: var(--space-4);
 }
 

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -135,6 +135,11 @@
   }
 {% endcall %}
 
+/* Partners section */
+.partners {
+  {{ utils.tango_to_white() }}
+}
+
 
 
 

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -115,6 +115,8 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;
+  max-width: var(--content-inner-max-width);
+  margin-inline: auto;
 }
 
 .katalyst > * {

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -48,15 +48,33 @@
   max-width: var(--freed-max-width);
 }
 
-.banner-area .widget-type-header h2 {
+.banner-area .widget-type-header {
   max-width: var(--content-inner-max-width);
   margin-inline: auto;
 }
 
-{% call utils.small() %}
+.banner-area .widget-type-header h2 {
+  {{ utils.dudler() }}
+  max-width: var(--dudler-max-width);
+}
+
+{% call utils.extra_large() %}
   .banner-area .dnd-row {
-    padding-left: 20px;
-    padding-right: 20px;
+      max-width: var(--content-max-width);
+      margin-inline: auto;
+  }
+{% endcall %}
+
+{% call utils.large() %}
+  .banner-area .dnd-row {
+    padding-left: 50px;
+    padding-right: 50px;
+  }
+{% endcall %}
+
+{% call utils.small_and_medium() %}
+  .dnd-row:nth-child(2) {
+    margin-top: var(--space-7);
   }
 {% endcall %}
 
@@ -67,16 +85,14 @@
   }
 {% endcall %}
 
-{% call utils.large() %}
-    .banner-area .dnd-row {
-      padding-left: 50px;
-      padding-right: 50px;
-    }
-{% endcall %}
-
-{% call utils.extra_large() %}
+{% call utils.small() %}
   .banner-area .dnd-row {
-      max-width: var(--content-max-width);
-      margin-inline: auto;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 {% endcall %}
+
+
+
+
+

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -1,5 +1,19 @@
 {% import '../utils/utils.css' as utils %}
 
+  .banner-area {
+    color: white;
+  } 
+
+  /* Overrides the default padding 0 */
+  .dnd-section {
+    padding-top: var(--space-7) !important;
+    padding-bottom: var(--space-7) !important;
+  }
+
+  .dnd-row:not(:first-child) {
+    margin-top: var(--space-7);
+  }
+
 {% call utils.small() %}
   .banner-area .dnd-row {
     padding-left: 20px;

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -11,28 +11,24 @@
   padding-bottom: var(--space-7) !important;
 }
 
-.dnd-row:not(:first-child):not(:last-child):not(:nth-child(2)) {
+.banner-area .dnd-row {
   margin-top: var(--space-7);
 }
 
-.dnd-row:last-child {
-  margin-top: var(--space-5);
-}
-
-.banner-area .dnd-column > .dnd-row:first-child .text-and-image__container {
+.banner-area .text-and-image__container {
   max-width: var(--content-max-width);
 }
 
-.banner-area .dnd-column > .dnd-row:first-child .text-and-image__copy {
+.banner-area .text-and-image__copy {
   max-width: unset;
   flex: 1 1;
 }
 
-.banner-area .dnd-column > .dnd-row:first-child h2 {
+.banner-area .text-and-image__copy h2 {
   {{ utils.eames() }}
 }
 
-.banner-area .dnd-column > .dnd-row:first-child p {
+.banner-area .text-and-image__copy p {
   {{ utils.freed() }}
   font-weight: var(--light-font-weight);
 }
@@ -57,16 +53,6 @@
   filter: brightness(0) invert(1);
 }
 
-.banner-area .widget-type-header {
-  max-width: var(--content-inner-max-width);
-  margin-inline: auto;
-}
-
-.banner-area .widget-type-header h2 {
-  {{ utils.dudler() }}
-  max-width: var(--dudler-max-width);
-}
-
 {% call utils.extra_large() %}
   .banner-area .dnd-row {
       max-width: var(--content-max-width);
@@ -78,12 +64,6 @@
   .banner-area .dnd-row {
     padding-left: 50px;
     padding-right: 50px;
-  }
-{% endcall %}
-
-{% call utils.small_and_medium() %}
-  .dnd-row:nth-child(2) {
-    margin-top: var(--space-7);
   }
 {% endcall %}
 
@@ -136,11 +116,6 @@
     flex-direction: column;
   }
 {% endcall %}
-
-/* Partners section */
-.partners {
-  {{ utils.tango_to_white() }}
-}
 
 
 

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -107,6 +107,34 @@
   margin-bottom: var(--space-4);
 }
 
+.katalyst {
+  display: flex;
+  --gap: var(--space-6);
+  gap: var(--gap);
+  background: url("https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD_katalyst_banner_BG.svg");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.katalyst > * {
+  flex: 1 1 calc(50% - var(--gap));
+}
+
+.katalyst__video .oembed_container,
+.katalyst__video iframe {
+  /* Overriding the default sizing styles */
+  max-width: 100% !important;
+  max-height: 100% !important;
+}
+
+{% call utils.small_and_medium() %}
+  .katalyst {
+    background-size: cover;
+    flex-direction: column;
+  }
+{% endcall %}
+
 
 
 

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -34,7 +34,7 @@
 }
 
 .banner-area .page-header.section-header h2 {
-  max-width: var(--eames-max-width);
+  max-width: var(--dudler-max-width);
 }
 
 .banner-area .page-header.section-header p {
@@ -86,15 +86,23 @@
 {% endcall %}
 
 /* Katalyst section */
+
+.katalyst .page-header.section-header {
+   /* Overrides default margin bottom */
+  margin-bottom: revert !important;
+}
+
+
 .katalyst .section-header h2 {
   {{ utils.dudler() }}
   font-weight: var(--heavy-font-weight);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-2);
 }
 
 .katalyst {
-  display: flex;
   --gap: var(--space-6);
+  display: flex;
+  align-items: center;
   gap: var(--gap);
   background: url("https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD_katalyst_banner_BG.svg");
   background-repeat: no-repeat;

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -1,5 +1,6 @@
 {% import '../utils/utils.css' as utils %}
 
+/* Hero banner section (DND) */
 .banner-area {
   color: white;
 } 
@@ -99,6 +100,12 @@
     padding-right: 20px;
   }
 {% endcall %}
+
+/* Katalyst section */
+.katalyst .section-header h2 {
+  {{ utils.dudler() }}
+  margin-bottom: var(--space-4);
+}
 
 
 

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -10,8 +10,12 @@
   padding-bottom: var(--space-7) !important;
 }
 
-.dnd-row:not(:first-child) {
+.dnd-row:not(:first-child):not(:last-child):not(:nth-child(2)) {
   margin-top: var(--space-7);
+}
+
+.dnd-row:last-child {
+  margin-top: var(--space-5);
 }
 
 .banner-area .dnd-column > .dnd-row:first-child .text-and-image__container {

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -11,10 +11,6 @@
   padding-bottom: var(--space-7) !important;
 }
 
-.banner-area .dnd-row {
-  margin-top: var(--space-7);
-}
-
 .banner-area .text-and-image__container {
   max-width: var(--content-max-width);
 }
@@ -43,6 +39,10 @@
 
 .banner-area .page-header.section-header p {
   max-width: var(--freed-max-width);
+}
+
+.banner-area .client-logos__content {
+  margin-top: var(--space-7);
 }
 
 .banner-area .client-logos__content h2 {
@@ -78,6 +78,10 @@
   .banner-area .dnd-row {
     padding-left: 20px;
     padding-right: 20px;
+  }
+
+  .banner-area .page-header.section-header {
+    margin-top: var(--space-7);
   }
 {% endcall %}
 

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -48,6 +48,14 @@
   max-width: var(--freed-max-width);
 }
 
+.banner-area .client-logos__content h2 {
+  color: white;
+}
+
+.banner-area .client-logos__logos-group {
+  filter: brightness(0) invert(1);
+}
+
 .banner-area .widget-type-header {
   max-width: var(--content-inner-max-width);
   margin-inline: auto;

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -5,8 +5,8 @@
 } 
 
 /* Overrides the default padding 0 */
-.dnd-section {
-  padding-top: var(--space-7) !important;
+.banner-area .dnd-section {
+  padding-top: var(--space-4) !important;
   padding-bottom: var(--space-7) !important;
 }
 
@@ -16,6 +16,20 @@
 
 .banner-area .dnd-column > .dnd-row:first-child .text-and-image__container {
   max-width: var(--content-max-width);
+}
+
+.banner-area .dnd-column > .dnd-row:first-child .text-and-image__copy {
+  max-width: unset;
+  flex: 1 1;
+}
+
+.banner-area .dnd-column > .dnd-row:first-child h2 {
+  {{ utils.eames() }}
+}
+
+.banner-area .dnd-column > .dnd-row:first-child p {
+  {{ utils.freed() }}
+  font-weight: var(--light-font-weight);
 }
 
 .banner-area .page-header.section-header {

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -1,0 +1,29 @@
+{% import '../utils/utils.css' as utils %}
+
+{% call utils.small() %}
+  .banner-area .dnd-row {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+{% endcall %}
+
+{% call utils.medium() %}
+  .banner-area .dnd-row {
+    padding-left: 25px;
+    padding-right: 25px;
+  }
+{% endcall %}
+
+{% call utils.large() %}
+    .banner-area .dnd-row {
+      padding-left: 50px;
+      padding-right: 50px;
+    }
+{% endcall %}
+
+{% call utils.extra_large() %}
+  .banner-area .dnd-row {
+      max-width: var(--content-max-width);
+      margin-inline: auto;
+  }
+{% endcall %}

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -31,6 +31,7 @@
 
 .banner-area .page-header.section-header {
   max-width: var(--content-inner-max-width);
+  margin-top: var(--space-3);
 }
 
 .banner-area .page-header.section-header h2 {

--- a/version_control/Codurance_September2020/css/pages/learning-and-development.css
+++ b/version_control/Codurance_September2020/css/pages/learning-and-development.css
@@ -102,6 +102,7 @@
 
 .katalyst > * {
   flex: 1 1 calc(50% - var(--gap));
+  width: 100%;
 }
 
 .katalyst .page-header.section-header {

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/fields.json
@@ -1,0 +1,135 @@
+[ {
+  "id" : "7c2b7da8-a0f4-a865-61db-7539c69b2041",
+  "name" : "course_cards",
+  "display_width" : null,
+  "label" : "Course cards",
+  "required" : false,
+  "locked" : false,
+  "occurrence" : {
+    "min" : null,
+    "max" : 6,
+    "sorting_label_field" : null,
+    "default" : null
+  },
+  "children" : [ {
+    "id" : "768dfb93-aff0-760e-4025-4ace414be69a",
+    "name" : "image",
+    "display_width" : null,
+    "label" : "Image",
+    "required" : false,
+    "locked" : false,
+    "responsive" : true,
+    "resizable" : true,
+    "show_loading" : false,
+    "type" : "image",
+    "default" : {
+      "size_type" : "auto",
+      "src" : "",
+      "alt" : null,
+      "loading" : "lazy"
+    }
+  }, {
+    "id" : "c78f4ddc-5bcf-84f5-d563-8e3462c00556",
+    "name" : "instructor",
+    "display_width" : null,
+    "label" : "Instructor",
+    "required" : false,
+    "locked" : false,
+    "table_name_or_id" : "5461253",
+    "columns_to_fetch" : [ "image", "name" ],
+    "display_columns" : [ "name" ],
+    "type" : "hubdbrow",
+    "default" : {
+      "id" : 81072539946
+    }
+  }, {
+    "id" : "8aaebebf-0aca-c049-eff1-afba96c90808",
+    "name" : "duration",
+    "display_width" : null,
+    "label" : "Duration",
+    "required" : false,
+    "locked" : false,
+    "validation_regex" : "",
+    "allow_new_line" : false,
+    "show_emoji_picker" : false,
+    "type" : "text"
+  }, {
+    "id" : "625fc537-664c-9bbf-753e-6f46874f6f8b",
+    "name" : "text_field",
+    "display_width" : null,
+    "label" : "Title",
+    "required" : false,
+    "locked" : false,
+    "validation_regex" : "",
+    "allow_new_line" : false,
+    "show_emoji_picker" : false,
+    "type" : "text"
+  }, {
+    "id" : "c053b299-14fd-3830-341c-ca10771f61bb",
+    "name" : "description",
+    "display_width" : null,
+    "label" : "Description",
+    "required" : false,
+    "locked" : false,
+    "validation_regex" : "",
+    "allow_new_line" : false,
+    "show_emoji_picker" : false,
+    "type" : "text"
+  }, {
+    "id" : "747af519-8897-3ff6-437c-1ee070342c7d",
+    "name" : "button",
+    "display_width" : null,
+    "label" : "Button",
+    "required" : false,
+    "locked" : false,
+    "children" : [ {
+      "id" : "39b107c0-3887-77d0-e79d-cb43cc4fd2bf",
+      "name" : "text",
+      "display_width" : null,
+      "label" : "Button Text",
+      "required" : false,
+      "locked" : false,
+      "validation_regex" : "",
+      "allow_new_line" : false,
+      "show_emoji_picker" : false,
+      "type" : "text"
+    }, {
+      "id" : "ff863fde-67b6-f9fd-fa14-e597b731d5fb",
+      "name" : "link",
+      "display_width" : null,
+      "label" : "Button Link",
+      "required" : false,
+      "locked" : false,
+      "supported_types" : [ "EXTERNAL", "CONTENT", "BLOG", "CALL_TO_ACTION" ],
+      "show_advanced_rel_options" : false,
+      "type" : "link",
+      "default" : {
+        "url" : {
+          "content_id" : null,
+          "href" : "",
+          "type" : "EXTERNAL"
+        },
+        "open_in_new_tab" : false,
+        "no_follow" : false
+      }
+    } ],
+    "tab" : "CONTENT",
+    "expanded" : false,
+    "type" : "group",
+    "default" : {
+      "link" : {
+        "url" : {
+          "content_id" : null,
+          "href" : "",
+          "type" : "EXTERNAL"
+        },
+        "open_in_new_tab" : false,
+        "no_follow" : false
+      }
+    }
+  } ],
+  "tab" : "CONTENT",
+  "expanded" : false,
+  "type" : "group",
+  "default" : [ ]
+} ]

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/fields.json
@@ -1,135 +1,151 @@
-[ {
-  "id" : "7c2b7da8-a0f4-a865-61db-7539c69b2041",
-  "name" : "course_cards",
-  "display_width" : null,
-  "label" : "Course cards",
-  "required" : false,
-  "locked" : false,
-  "occurrence" : {
-    "min" : null,
-    "max" : 6,
-    "sorting_label_field" : null,
-    "default" : null
-  },
-  "children" : [ {
-    "id" : "768dfb93-aff0-760e-4025-4ace414be69a",
-    "name" : "image",
-    "display_width" : null,
-    "label" : "Image",
-    "required" : false,
-    "locked" : false,
-    "responsive" : true,
-    "resizable" : true,
-    "show_loading" : false,
-    "type" : "image",
-    "default" : {
-      "size_type" : "auto",
-      "src" : "",
-      "alt" : null,
-      "loading" : "lazy"
-    }
-  }, {
-    "id" : "c78f4ddc-5bcf-84f5-d563-8e3462c00556",
-    "name" : "instructor",
-    "display_width" : null,
-    "label" : "Instructor",
-    "required" : false,
-    "locked" : false,
-    "table_name_or_id" : "5461253",
-    "columns_to_fetch" : [ "image", "name" ],
-    "display_columns" : [ "name" ],
-    "type" : "hubdbrow",
-    "default" : {
-      "id" : 81072539946
-    }
-  }, {
-    "id" : "8aaebebf-0aca-c049-eff1-afba96c90808",
-    "name" : "duration",
-    "display_width" : null,
-    "label" : "Duration",
-    "required" : false,
-    "locked" : false,
-    "validation_regex" : "",
-    "allow_new_line" : false,
-    "show_emoji_picker" : false,
-    "type" : "text"
-  }, {
-    "id" : "625fc537-664c-9bbf-753e-6f46874f6f8b",
-    "name" : "text_field",
-    "display_width" : null,
-    "label" : "Title",
-    "required" : false,
-    "locked" : false,
-    "validation_regex" : "",
-    "allow_new_line" : false,
-    "show_emoji_picker" : false,
-    "type" : "text"
-  }, {
-    "id" : "c053b299-14fd-3830-341c-ca10771f61bb",
-    "name" : "description",
-    "display_width" : null,
-    "label" : "Description",
-    "required" : false,
-    "locked" : false,
-    "validation_regex" : "",
-    "allow_new_line" : false,
-    "show_emoji_picker" : false,
-    "type" : "text"
-  }, {
-    "id" : "747af519-8897-3ff6-437c-1ee070342c7d",
-    "name" : "button",
-    "display_width" : null,
-    "label" : "Button",
-    "required" : false,
-    "locked" : false,
-    "children" : [ {
-      "id" : "39b107c0-3887-77d0-e79d-cb43cc4fd2bf",
-      "name" : "text",
-      "display_width" : null,
-      "label" : "Button Text",
-      "required" : false,
-      "locked" : false,
-      "validation_regex" : "",
-      "allow_new_line" : false,
-      "show_emoji_picker" : false,
-      "type" : "text"
-    }, {
-      "id" : "ff863fde-67b6-f9fd-fa14-e597b731d5fb",
-      "name" : "link",
-      "display_width" : null,
-      "label" : "Button Link",
-      "required" : false,
-      "locked" : false,
-      "supported_types" : [ "EXTERNAL", "CONTENT", "BLOG", "CALL_TO_ACTION" ],
-      "show_advanced_rel_options" : false,
-      "type" : "link",
-      "default" : {
-        "url" : {
-          "content_id" : null,
-          "href" : "",
-          "type" : "EXTERNAL"
-        },
-        "open_in_new_tab" : false,
-        "no_follow" : false
+[
+  {
+    "id": "7c2b7da8-a0f4-a865-61db-7539c69b2041",
+    "name": "course_cards",
+    "display_width": null,
+    "label": "Course cards",
+    "required": false,
+    "locked": false,
+    "occurrence": {
+      "min": null,
+      "max": 6,
+      "sorting_label_field": null,
+      "default": null
+    },
+    "children": [
+      {
+        "id": "768dfb93-aff0-760e-4025-4ace414be69a",
+        "name": "image",
+        "display_width": null,
+        "label": "Image",
+        "required": false,
+        "locked": false,
+        "responsive": true,
+        "resizable": true,
+        "show_loading": false,
+        "type": "image",
+        "default": {
+          "size_type": "auto",
+          "src": "",
+          "alt": null,
+          "loading": "lazy"
+        }
+      },
+      {
+        "id": "c78f4ddc-5bcf-84f5-d563-8e3462c00556",
+        "name": "instructor",
+        "display_width": null,
+        "label": "Instructor",
+        "required": false,
+        "locked": false,
+        "table_name_or_id": "our_people",
+        "columns_to_fetch": ["image", "name"],
+        "display_columns": ["name"],
+        "type": "hubdbrow"
+      },
+      {
+        "name": "duration",
+        "label": "duration",
+        "required": false,
+        "locked": false,
+        "display": "text",
+        "step": 1,
+        "type": "number",
+        "min": null,
+        "max": null,
+        "inline_help_text": "",
+        "help_text": "",
+        "default": 1
+      },
+      {
+        "id": "625fc537-664c-9bbf-753e-6f46874f6f8b",
+        "name": "title",
+        "display_width": null,
+        "label": "Title",
+        "required": false,
+        "locked": false,
+        "validation_regex": "",
+        "allow_new_line": false,
+        "show_emoji_picker": false,
+        "type": "text"
+      },
+      {
+        "id": "c053b299-14fd-3830-341c-ca10771f61bb",
+        "name": "description",
+        "display_width": null,
+        "label": "Description",
+        "required": false,
+        "locked": false,
+        "validation_regex": "",
+        "allow_new_line": false,
+        "show_emoji_picker": false,
+        "type": "text"
+      },
+      {
+        "id": "747af519-8897-3ff6-437c-1ee070342c7d",
+        "name": "button",
+        "display_width": null,
+        "label": "Button",
+        "required": false,
+        "locked": false,
+        "children": [
+          {
+            "id": "39b107c0-3887-77d0-e79d-cb43cc4fd2bf",
+            "name": "text",
+            "display_width": null,
+            "label": "Button Text",
+            "required": false,
+            "locked": false,
+            "validation_regex": "",
+            "allow_new_line": false,
+            "show_emoji_picker": false,
+            "type": "text"
+          },
+          {
+            "id": "ff863fde-67b6-f9fd-fa14-e597b731d5fb",
+            "name": "link",
+            "display_width": null,
+            "label": "Button Link",
+            "required": false,
+            "locked": false,
+            "supported_types": [
+              "EXTERNAL",
+              "CONTENT",
+              "BLOG",
+              "CALL_TO_ACTION"
+            ],
+            "show_advanced_rel_options": false,
+            "type": "link",
+            "default": {
+              "url": {
+                "content_id": null,
+                "href": "",
+                "type": "EXTERNAL"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            }
+          }
+        ],
+        "tab": "CONTENT",
+        "expanded": false,
+        "type": "group",
+        "default": {
+          "link": {
+            "url": {
+              "content_id": null,
+              "href": "",
+              "type": "EXTERNAL"
+            },
+            "open_in_new_tab": false,
+            "no_follow": false
+          }
+        }
       }
-    } ],
-    "tab" : "CONTENT",
-    "expanded" : false,
-    "type" : "group",
-    "default" : {
-      "link" : {
-        "url" : {
-          "content_id" : null,
-          "href" : "",
-          "type" : "EXTERNAL"
-        },
-        "open_in_new_tab" : false,
-        "no_follow" : false
-      }
-    }
-  } ],
-  "tab" : "CONTENT",
-  "expanded" : false,
-  "type" : "group",
-  "default" : [ ]
-} ]
+    ],
+    "tab": "CONTENT",
+    "expanded": false,
+    "type": "group",
+    "default": []
+  }
+]

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/meta.json
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/meta.json
@@ -1,0 +1,6 @@
+{
+  "global" : false,
+  "host_template_types" : [ "PAGE" ],
+  "module_id" : 132044450205,
+  "is_available_for_new_content" : true
+}

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
@@ -1,31 +1,38 @@
 
+<div class="course-card-group" >
+	{% for course in module.course_cards %}
 
-
-{% for course in module.course_cards %}
-	{% if course.image.src %}
-		{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}"' %}
-		{% if course.image.size_type == 'auto' %}
-			{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}" style="max-width: 100%; height: auto;"' %}
-		{% elif course.image.size_type == 'auto_custom_max' %}
-			{% set sizeAttrs = 'width="{{ course.image.max_width }}" height="{{ course.image.max_height }}" style="max-width: 100%; height: auto;"' %}
-		{% endif %}
-		{% set loadingAttr = course.image.loading != 'disabled' ? 'loading="{{ course.image.loading }}"' : '' %}
-		<img src="{{ course.image.src }}" alt="{{ course.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
-	{% endif %}
-
-
-	{{ module.instructor.columns.image.url }}
-	{{ module.instructor.columns.name }}
-
-	{{ course.duration }}
-	{{ course.text_field }}
-	<p>{{ course.description }}</p>
-
-	{% set href = course.button.link.url.href %}
-	<a class="button-primary" href="{{ href }}"
-		{% if course.button.link.open_in_new_tab %}target="_blank"{% endif %}
-		{% if course.button.link.rel %}rel="{{ course.button.link.rel }}"{% endif %}
-		>
-    	{{ course.button.text }}
-	</a>
-{% endfor %}
+		<article class="course-card">
+			{% if course.image.src %}
+				{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}"' %}
+				{% if course.image.size_type == 'auto' %}
+					{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}" style="max-width: 100%; height: auto;"' %}
+				{% elif course.image.size_type == 'auto_custom_max' %}
+					{% set sizeAttrs = 'width="{{ course.image.max_width }}" height="{{ course.image.max_height }}" style="max-width: 100%; height: auto;"' %}
+				{% endif %}
+				{% set loadingAttr = course.image.loading != 'disabled' ? 'loading="{{ course.image.loading }}"' : '' %}
+				<img src="{{ course.image.src }}" alt="{{ course.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
+			{% endif %}
+			<div class="course-info">
+				<h3>{{ course.title }}</h3>
+				<div class="course-info__instructor">
+					<img src="{{course.instructor.columns.image.url}}" alt="{{ course.instructor.columns.image.name }} profile picture" />
+			
+					<p>
+						{{ course.instructor.columns.name }} | <span>{{ course.duration }}days</span>
+					</p>
+				</div>
+				<p>{{ course.description }}</p>
+			</div>
+			{% set href = course.button.link.url.href %}
+			{% if course.button.text %}
+				<a class="button-primary" href="{{ href }}"
+					{% if course.button.link.open_in_new_tab %}target="_blank"{% endif %}
+					{% if course.button.link.rel %}rel="{{ course.button.link.rel }}"{% endif %}
+					>
+					{{ course.button.text }}
+				</a>
+			{% endif %}
+		</article>
+	{% endfor %}
+</div>

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
@@ -1,0 +1,31 @@
+
+
+
+{% for course in module.course_cards %}
+	{% if course.image.src %}
+		{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}"' %}
+		{% if course.image.size_type == 'auto' %}
+			{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}" style="max-width: 100%; height: auto;"' %}
+		{% elif course.image.size_type == 'auto_custom_max' %}
+			{% set sizeAttrs = 'width="{{ course.image.max_width }}" height="{{ course.image.max_height }}" style="max-width: 100%; height: auto;"' %}
+		{% endif %}
+		{% set loadingAttr = course.image.loading != 'disabled' ? 'loading="{{ course.image.loading }}"' : '' %}
+		<img src="{{ course.image.src }}" alt="{{ course.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
+	{% endif %}
+
+
+	{{ module.instructor.columns.image.url }}
+	{{ module.instructor.columns.name }}
+
+	{{ course.duration }}
+	{{ course.text_field }}
+	<p>{{ course.description }}</p>
+
+	{% set href = course.button.link.url.href %}
+	<a class="button-primary" href="{{ href }}"
+		{% if course.button.link.open_in_new_tab %}target="_blank"{% endif %}
+		{% if course.button.link.rel %}rel="{{ course.button.link.rel }}"{% endif %}
+		>
+    	{{ course.button.text }}
+	</a>
+{% endfor %}

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
@@ -1,6 +1,9 @@
+{{ require_css(get_asset_url("../../css/modules/course-cards.css")) }} 
+
 
 <div class="course-card-group" >
-	{% for course in module.course_cards %}
+{% for course in module.course_cards %}
+	{% set avatar_image = resize_image_url(course.instructor.columns.image.url, 70) %}
 
 		<article class="course-card">
 			{% if course.image.src %}
@@ -13,26 +16,24 @@
 				{% set loadingAttr = course.image.loading != 'disabled' ? 'loading="{{ course.image.loading }}"' : '' %}
 				<img src="{{ course.image.src }}" alt="{{ course.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
 			{% endif %}
-			<div class="course-info">
+			<div class="course-content">
 				<h3>{{ course.title }}</h3>
 				<div class="course-info__instructor">
-					<img src="{{course.instructor.columns.image.url}}" alt="{{ course.instructor.columns.image.name }} profile picture" />
-			
-					<p>
-						{{ course.instructor.columns.name }} | <span>{{ course.duration }}days</span>
-					</p>
+					<img src="{{ avatar_image }}" alt="{{ course.instructor.columns.image.name }} profile picture" />
+					<p>Hosted by: {{ course.instructor.columns.name }} | <span>{{ course.duration }} days</span></p>
 				</div>
 				<p>{{ course.description }}</p>
+
+				{% set href = course.button.link.url.href %}
+				{% if course.button.text %}
+					<a class="button-primary" href="{{ href }}"
+						{% if course.button.link.open_in_new_tab %}target="_blank"{% endif %}
+						{% if course.button.link.rel %}rel="{{ course.button.link.rel }}"{% endif %}
+						>
+						{{ course.button.text }}
+					</a>
+				{% endif %}
 			</div>
-			{% set href = course.button.link.url.href %}
-			{% if course.button.text %}
-				<a class="button-primary" href="{{ href }}"
-					{% if course.button.link.open_in_new_tab %}target="_blank"{% endif %}
-					{% if course.button.link.rel %}rel="{{ course.button.link.rel }}"{% endif %}
-					>
-					{{ course.button.text }}
-				</a>
-			{% endif %}
 		</article>
 	{% endfor %}
 </div>

--- a/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
+++ b/version_control/Codurance_September2020/modules/Course-Cards.module/module.html
@@ -1,11 +1,12 @@
 {{ require_css(get_asset_url("../../css/modules/course-cards.css")) }} 
 
-
 <div class="course-card-group" >
 {% for course in module.course_cards %}
 	{% set avatar_image = resize_image_url(course.instructor.columns.image.url, 70) %}
+	{% set is_featured_card = loop.index == 1 ? " featured-card" : null %}
 
-		<article class="course-card">
+
+		<article class="course-card{{is_featured_card}}">
 			{% if course.image.src %}
 				{% set sizeAttrs = 'width="{{ course.image.width }}" height="{{ course.image.height }}"' %}
 				{% if course.image.size_type == 'auto' %}
@@ -14,13 +15,13 @@
 					{% set sizeAttrs = 'width="{{ course.image.max_width }}" height="{{ course.image.max_height }}" style="max-width: 100%; height: auto;"' %}
 				{% endif %}
 				{% set loadingAttr = course.image.loading != 'disabled' ? 'loading="{{ course.image.loading }}"' : '' %}
-				<img src="{{ course.image.src }}" alt="{{ course.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
+				<img class="course-card__image" src="{{ course.image.src }}" alt="{{ course.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
 			{% endif %}
 			<div class="course-content">
 				<h3>{{ course.title }}</h3>
 				<div class="course-info__instructor">
 					<img src="{{ avatar_image }}" alt="{{ course.instructor.columns.image.name }} profile picture" />
-					<p>Hosted by: {{ course.instructor.columns.name }} | <span>{{ course.duration }} days</span></p>
+					<p>Hosted by {{ course.instructor.columns.name }} | <span>{{ course.duration }} days</span></p>
 				</div>
 				<p>{{ course.description }}</p>
 

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -21,8 +21,8 @@ label: Learning and Development Page
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-      {% dnd_section%}
-
+    	{% dnd_section %}
+			{% dnd_column %}
 				{% dnd_row %}
 					{% dnd_module
 						path="/version_control/Codurance_September2020/modules/Text-and-image",
@@ -48,6 +48,7 @@ label: Learning and Development Page
 						{% end_module_attribute %}
 					{% end_dnd_module %}
 				{% end_dnd_row %}
+
 				{% dnd_row %}
 					{% dnd_module
 						path="@hubspot/rich_text",
@@ -94,8 +95,8 @@ label: Learning and Development Page
 						{% end_module_attribute %}
 					{% end_dnd_module %}
 				{% end_dnd_row %}
-		
-			{% end_dnd_section %}
+			{% end_dnd_column %}
+		{% end_dnd_section %}
     {% end_dnd_area %}
   </div>
 

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -6,6 +6,7 @@ label: Learning and Development Page
 {% extends "./layouts/base.html" %}
 
 {{ require_css(get_asset_url("../css/pages/services-inner.css")) }}
+{{ require_css(get_asset_url("../css/pages/learning-and-development.css")) }}
 
 {% require_css %}
   <style>

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -9,90 +9,21 @@ label: Learning and Development Page
 {{ require_css(get_asset_url("../css/pages/learning-and-development.css")) }}
 
 {% require_css %}
-  <style>
-    .banner-area .dnd-section > .row-fluid {
-		background: url({% image_src "banner_background_image" src="https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LDD_shape_BG.svg" label="Background Image" no_wrapper=True %});
-		background-position: right 60%, center;
-		background-repeat: no-repeat;
-		background-size: 30%;
-    }
-  </style>
+    <style>
+        .banner-area .dnd-section > .row-fluid {
+            background: url({% image_src "banner_background_image" src="https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LDD_shape_BG.svg" label="Background Image" no_wrapper=True %});
+            background-position: right 60%, center;
+            background-repeat: no-repeat;
+            background-size: 30%;
+        }
+    </style>
 {% end_require_css %}
 
 {% block body %}
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-		{% dnd_section 
-			background_linear_gradient={
-				"direction": "to bottom",
-				"colors": [
-					"#0F0F0F",
-					"#59BCCC"
-				]
-			},
-			full_width=true 
-		%}
-			{% dnd_column %}
-				{% dnd_row %}
-					{% dnd_module
-						path="/version_control/Codurance_September2020/modules/Text-and-image",
-						offset=0,
-						width=12,
-						title="Learning & Development",
-						image_field={ 
-							src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-hero.png"
-						}
-					%}
-						{% module_attribute "description_text" %}
-							<p>Improve the skills of your teams and promote their technical excellence, to achieve better results in your business.</p>
-						{% end_module_attribute %}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module
-						path="@hubspot/section_header",
-						offset=0,
-						width=12,
-						header="Empower your technology teams with focused training from our world class experts",
-						heading_level="h2",
-						subheader="Enhance your team’s skillset with our industry leading training courses. We create bespoke training plans adapted to your business needs."
-					%}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module
-						path="/version_control/Codurance_September2020/modules/Course-Cards",
-						offset=0,
-						width=12
-					%}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module
-						path="/version_control/Codurance_September2020/modules/Clients-Logos",
-						offset=0,
-						width=12,
-						logos_group=[ {
-							"logo" : {
-								"alt" : "Envoy-logo",
-								"height" : 190,
-								"loading" : "lazy",
-								"max_height" : 190,
-								"max_width" : 579,
-								"size_type" : "auto",
-								"src" : "https://14557846.fs1.hubspotusercontent-na1.net/hubfs/14557846/Imported%20sitepage%20images/Envoy-logo.png",
-								"width" : 579
-							}
-						} ]
-					%}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-			{% end_dnd_column %}
-		{% end_dnd_section %}
+		{% include_dnd_partial path='./sections/service-line-hero.html' context={} %}
     {% end_dnd_area %}
   </div>
 

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -7,15 +7,98 @@ label: Learning and Development Page
 
 {{ require_css(get_asset_url("../css/pages/services-inner.css")) }}
 
+{% require_css %}
+  <style>
+    .banner-area .dnd-section > .row-fluid {
+			background: url({% image_src "banner_background_image" label="Background Image" no_wrapper=True %});
+			background-position: right, center;
+			background-repeat: no-repeat;
+    }
+  </style>
+{% end_require_css %}
+
 {% block body %}
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-      {% dnd_section full_width=true %}
-        
-      {% end_dnd_section %}
+      {% dnd_section%}
+
+				{% dnd_row %}
+					{% dnd_module
+						path="/version_control/Codurance_September2020/modules/Text-and-image",
+						offset=0,
+						width=12,
+						title="Learning & Development"
+					%}
+						{% module_attribute "description_text" %}
+							<h1>Improve the skills of your teams and promote their technical excellence, to achieve better results in your business.</h1>
+						{% end_module_attribute %}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+
+				{% dnd_row %}
+					{% dnd_module
+						path="/version_control/Codurance_September2020/modules/Text-and-image",
+						offset=0,
+						width=12,
+						image_order="img-left"
+					%}
+						{% module_attribute "description_text" %}
+							We assess your highest priorities to create your bespoke training program and offer practical and theoretical programs, tailored to your precise needs, which guarantees your teams increased performance.
+						{% end_module_attribute %}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+				{% dnd_row %}
+					{% dnd_module
+						path="@hubspot/rich_text",
+						offset=0,
+						width=12
+					%}
+						{% module_attribute "html" %}
+							<h2>Empower your technology teams with focused training from our world class experts</h2>
+							<p>Enhance your team’s skillset with our industry leading training courses. We create bespoke training plans adapted to your business needs.</p>
+						{% end_module_attribute %}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+
+				{% dnd_row %}
+					{% dnd_module
+						path="/version_control/Codurance_September2020/modules/Clients-Logos",
+						offset=0,
+						width=12,
+						logos_group=[ {
+							"logo" : {
+								"alt" : "Envoy-logo",
+								"height" : 190,
+								"loading" : "lazy",
+								"max_height" : 190,
+								"max_width" : 579,
+								"size_type" : "auto",
+								"src" : "https://14557846.fs1.hubspotusercontent-na1.net/hubfs/14557846/Imported%20sitepage%20images/Envoy-logo.png",
+								"width" : 579
+							}
+						} ]
+					%}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+
+				{% dnd_row %}
+					{% dnd_module
+						path="/version_control/Codurance_September2020/modules/Text-and-image",
+						offset=0,
+						width=12,
+						title="Accelerate excellence"
+					%}
+						{% module_attribute "description_text" %}
+							Training your in-house team is usually more cost effective than hiring new talent with the required skills. You’ll discover that our programs generate an organisation-wide transformation, creating a lasting positive impact that goes beyond the software development teams.
+						{% end_module_attribute %}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+		
+			{% end_dnd_section %}
     {% end_dnd_area %}
   </div>
+
   <main class="body-container-wrapper">
 
     <section class="katalyst">

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -39,7 +39,10 @@ label: Learning and Development Page
 						path="/version_control/Codurance_September2020/modules/Text-and-image",
 						offset=0,
 						width=12,
-						title="Learning & Development"
+						title="Learning & Development",
+						image_field={ 
+							src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-hero.png"
+						}
 					%}
 						{% module_attribute "description_text" %}
 							<p>Improve the skills of your teams and promote their technical excellence, to achieve better results in your business.</p>

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -52,22 +52,6 @@ label: Learning and Development Page
 
 				{% dnd_row %}
 					{% dnd_module
-						path="/version_control/Codurance_September2020/modules/Text-and-image",
-						offset=0,
-						width=12,
-						image_order="img-left",
-						image_field={ 
-							src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-2.png"
-						}
-					%}
-						{% module_attribute "description_text" %}
-							We assess your highest priorities to create your bespoke training program and offer practical and theoretical programs, tailored to your precise needs, which guarantees your teams increased performance.
-						{% end_module_attribute %}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module
 						path="/version_control/Codurance_September2020/modules/Course-Cards",
 						offset=0,
 						width=12
@@ -107,30 +91,6 @@ label: Learning and Development Page
 					%}
 					{% end_dnd_module %}
 				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module  
-						path="@hubspot/header", 
-						value="Programas prácticos y teóricos que garantizan la aceleración de la excelencia de tus equipos porque:",
-						header_tag="h2"
-					%}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module
-						path="/version_control/Codurance_September2020/modules/Text-and-image",
-						title="Accelerate excellence",
-						image_order="img-left",
-						image_field={ 
-							src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-1.png"
-						}
-					%}
-						{% module_attribute "description_text" %}
-							Training your in-house team is usually more cost effective than hiring new talent with the required skills. You’ll discover that our programs generate an organisation-wide transformation, creating a lasting positive impact that goes beyond the software development teams.
-						{% end_module_attribute %}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
 			{% end_dnd_column %}
 		{% end_dnd_section %}
     {% end_dnd_area %}
@@ -149,10 +109,6 @@ label: Learning and Development Page
 		</div>
 
 		{% module "katalyst_video" path="@hubspot/video" label="Katalyst video" extra_classes="katalyst__video" %}
-    </section>
-
-    <section class="partners region">
-      {% global_partial path="./partials/partners-section.html" %}
     </section>
 
     <section class="cm-services-inner-bottom-wrap" id="get-in-touch">

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -52,21 +52,21 @@ label: Learning and Development Page
 
 				{% dnd_row %}
 					{% dnd_module
-						path="/version_control/Codurance_September2020/modules/Course-Cards",
-						offset=0,
-						width=12
-					%}
-					{% end_dnd_module %}
-				{% end_dnd_row %}
-
-				{% dnd_row %}
-					{% dnd_module
 						path="@hubspot/section_header",
 						offset=0,
 						width=12,
 						header="Empower your technology teams with focused training from our world class experts",
 						heading_level="h2",
 						subheader="Enhance your team’s skillset with our industry leading training courses. We create bespoke training plans adapted to your business needs."
+					%}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+
+				{% dnd_row %}
+					{% dnd_module
+						path="/version_control/Codurance_September2020/modules/Course-Cards",
+						offset=0,
+						width=12
 					%}
 					{% end_dnd_module %}
 				{% end_dnd_row %}

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -128,10 +128,14 @@ label: Learning and Development Page
   </div>
 
   <main class="body-container-wrapper">
-
-    <section class="katalyst">
-      {% dnd_area "dnd_area_katalyst" label='Katalyst section' %}
-      {% end_dnd_area %}
+    <section class="katalyst region lateral-spacing responsive-page-width">
+		{% section_header "katalyst_header" 
+			heading_level="h2",
+			label="Katalyst header", 
+			header="Katalyst by Codurance",
+			subheader="Discover Katalyst by Codurance, the ultimate service to empower your team, boost productivity and streamline onboarding processes. Dive into our all-encompassing suite of resources tailored to elevate your team's performance: engaging training and e-learning courses, expert technical coaching for teams, customised technical coaching programs, bespoke internal academies, and much more."
+		%}
+		{% module "katalyst_cta" path="../modules/Button.module" label="Katalyst CTA" button_type="std" %}
     </section>
 
     <section class="section-4">

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -11,10 +11,10 @@ label: Learning and Development Page
 {% require_css %}
   <style>
     .banner-area .dnd-section > .row-fluid {
-			background: url({% image_src "banner_background_image" label="Background Image" no_wrapper=True %});
-				background-position: right 40%, center;
-				background-repeat: no-repeat;
-				background-size: 40%;
+		background: url({% image_src "banner_background_image" src="https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LDD_shape_BG.svg" label="Background Image" no_wrapper=True %});
+		background-position: right 40%, center;
+		background-repeat: no-repeat;
+		background-size: 40%;
     }
   </style>
 {% end_require_css %}
@@ -23,12 +23,20 @@ label: Learning and Development Page
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-    	{% dnd_section 
+		{% dnd_section 
 			padding={
 			"top": 100,
 			"bottom": 100
-			}
-		full_width=true %}
+			},
+			background_linear_gradient={
+				"direction": "to bottom",
+				"colors": [
+					"#0F0F0F",
+					"#59BCCC"
+				]
+			},
+			full_width=true 
+		%}
 			{% dnd_column %}
 				{% dnd_row %}
 					{% dnd_module
@@ -38,7 +46,7 @@ label: Learning and Development Page
 						title="Learning & Development"
 					%}
 						{% module_attribute "description_text" %}
-							<h1>Improve the skills of your teams and promote their technical excellence, to achieve better results in your business.</h1>
+							<p>Improve the skills of your teams and promote their technical excellence, to achieve better results in your business.</p>
 						{% end_module_attribute %}
 					{% end_dnd_module %}
 				{% end_dnd_row %}
@@ -48,7 +56,10 @@ label: Learning and Development Page
 						path="/version_control/Codurance_September2020/modules/Text-and-image",
 						offset=0,
 						width=12,
-						image_order="img-left"
+						image_order="img-left",
+						image_field={ 
+							src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-2.png"
+						}
 					%}
 						{% module_attribute "description_text" %}
 							We assess your highest priorities to create your bespoke training program and offer practical and theoretical programs, tailored to your precise needs, which guarantees your teams increased performance.
@@ -58,14 +69,13 @@ label: Learning and Development Page
 
 				{% dnd_row %}
 					{% dnd_module
-						path="@hubspot/rich_text",
+						path="@hubspot/section_header",
 						offset=0,
-						width=12
+						width=12,
+						header="Empower your technology teams with focused training from our world class experts",
+						heading_level="h2",
+						subheader="Enhance your team’s skillset with our industry leading training courses. We create bespoke training plans adapted to your business needs."
 					%}
-						{% module_attribute "html" %}
-							<h2>Empower your technology teams with focused training from our world class experts</h2>
-							<p>Enhance your team’s skillset with our industry leading training courses. We create bespoke training plans adapted to your business needs.</p>
-						{% end_module_attribute %}
 					{% end_dnd_module %}
 				{% end_dnd_row %}
 
@@ -91,11 +101,22 @@ label: Learning and Development Page
 				{% end_dnd_row %}
 
 				{% dnd_row %}
+					{% dnd_module  
+						path="@hubspot/header", 
+						value="Programas prácticos y teóricos que garantizan la aceleración de la excelencia de tus equipos porque:",
+						header_tag="h2"
+					%}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+
+				{% dnd_row %}
 					{% dnd_module
 						path="/version_control/Codurance_September2020/modules/Text-and-image",
-						offset=0,
-						width=12,
-						title="Accelerate excellence"
+						title="Accelerate excellence",
+						image_order="img-left",
+						image_field={ 
+							src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-1.png"
+						}
 					%}
 						{% module_attribute "description_text" %}
 							Training your in-house team is usually more cost effective than hiring new talent with the required skills. You’ll discover that our programs generate an organisation-wide transformation, creating a lasting positive impact that goes beyond the software development teams.
@@ -124,7 +145,7 @@ label: Learning and Development Page
 					max_width=1200,
 					vertical_alignment='TOP'
 				%}
-						{% dnd_module 'sl_form'
+					{% dnd_module 'sl_form'
 						path='../modules/Service-Line-Form.module'
 					%}
 					{% end_dnd_module %}

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -1,0 +1,36 @@
+<!--
+templateType: page
+isAvailableForNewContent: true
+label: Learning and Development Page
+-->
+{% extends "./layouts/base.html" %}
+
+{{ require_css(get_asset_url("../css/pages/services-inner.css")) }}
+
+{% block body %}
+<div class="cm-services-inner-layout type1">
+  <div class="banner-section">
+    {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
+      {% dnd_section full_width=true %}
+        
+      {% end_dnd_section %}
+    {% end_dnd_area %}
+  </div>
+  <main class="body-container-wrapper">
+
+    <section class="katalyst">
+      {% dnd_area "dnd_area_katalyst" label='Katalyst section' %}
+      {% end_dnd_area %}
+    </section>
+
+    <section class="section-4">
+      {% global_partial path="./partials/partners-section.html" %}
+    </section>
+
+    <section class="cm-services-inner-bottom-wrap" id="get-in-touch">
+      {% dnd_area "dnd_area_contact" label='Contact us section' %}
+      {% end_dnd_area %}
+    </section>
+  </main>
+</div>
+{% endblock body %}

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -12,8 +12,9 @@ label: Learning and Development Page
   <style>
     .banner-area .dnd-section > .row-fluid {
 			background: url({% image_src "banner_background_image" label="Background Image" no_wrapper=True %});
-			background-position: right, center;
-			background-repeat: no-repeat;
+				background-position: right 40%, center;
+				background-repeat: no-repeat;
+				background-size: 40%;
     }
   </style>
 {% end_require_css %}
@@ -22,7 +23,12 @@ label: Learning and Development Page
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-    	{% dnd_section full_width=true %}
+    	{% dnd_section 
+			padding={
+			"top": 100,
+			"bottom": 100
+			}
+		full_width=true %}
 			{% dnd_column %}
 				{% dnd_row %}
 					{% dnd_module

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -12,9 +12,9 @@ label: Learning and Development Page
   <style>
     .banner-area .dnd-section > .row-fluid {
 		background: url({% image_src "banner_background_image" src="https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LDD_shape_BG.svg" label="Background Image" no_wrapper=True %});
-		background-position: right 40%, center;
+		background-position: right 60%, center;
 		background-repeat: no-repeat;
-		background-size: 40%;
+		background-size: 30%;
     }
   </style>
 {% end_require_css %}

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -68,6 +68,15 @@ label: Learning and Development Page
 
 				{% dnd_row %}
 					{% dnd_module
+						path="/version_control/Codurance_September2020/modules/Course-Cards",
+						offset=0,
+						width=12
+					%}
+					{% end_dnd_module %}
+				{% end_dnd_row %}
+
+				{% dnd_row %}
+					{% dnd_module
 						path="@hubspot/section_header",
 						offset=0,
 						width=12,
@@ -148,16 +157,15 @@ label: Learning and Development Page
 
     <section class="cm-services-inner-bottom-wrap" id="get-in-touch">
       {% dnd_area "dnd_area_contact" label='Contact section' %}
-				{% dnd_section 
-					max_width=1200,
-					vertical_alignment='TOP'
-				%}
-					{% dnd_module 'sl_form'
-						path='../modules/Service-Line-Form.module'
-					%}
-					{% end_dnd_module %}
-				{% end_dnd_section %}
-				
+		{% dnd_section 
+			max_width=1200,
+			vertical_alignment='TOP'
+		%}
+			{% dnd_module 'sl_form'
+				path='../modules/Service-Line-Form.module'
+			%}
+			{% end_dnd_module %}
+		{% end_dnd_section %}
       {% end_dnd_area %}
     </section>
   </main>

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -118,7 +118,17 @@ label: Learning and Development Page
     </section>
 
     <section class="cm-services-inner-bottom-wrap" id="get-in-touch">
-      {% dnd_area "dnd_area_contact" label='Contact us section' %}
+      {% dnd_area "dnd_area_contact" label='Contact section' %}
+				{% dnd_section 
+					max_width=1200,
+					vertical_alignment='TOP'
+				%}
+						{% dnd_module 'sl_form'
+						path='../modules/Service-Line-Form.module'
+					%}
+					{% end_dnd_module %}
+				{% end_dnd_section %}
+				
       {% end_dnd_area %}
     </section>
   </main>

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -24,10 +24,6 @@ label: Learning and Development Page
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
 		{% dnd_section 
-			padding={
-			"top": 100,
-			"bottom": 100
-			},
 			background_linear_gradient={
 				"direction": "to bottom",
 				"colors": [

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -128,7 +128,7 @@ label: Learning and Development Page
   </div>
 
   <main class="body-container-wrapper">
-    <section class="katalyst region lateral-spacing responsive-page-width">
+    <section class="katalyst region lateral-spacing">
 		<div class="katalyst__content">
 			{% section_header "katalyst_header" 
 				heading_level="h2",

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -142,7 +142,7 @@ label: Learning and Development Page
 		{% module "katalyst_video" path="@hubspot/video" label="Katalyst video" extra_classes="katalyst__video" %}
     </section>
 
-    <section class="section-4">
+    <section class="partners region">
       {% global_partial path="./partials/partners-section.html" %}
     </section>
 

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -129,13 +129,17 @@ label: Learning and Development Page
 
   <main class="body-container-wrapper">
     <section class="katalyst region lateral-spacing responsive-page-width">
-		{% section_header "katalyst_header" 
-			heading_level="h2",
-			label="Katalyst header", 
-			header="Katalyst by Codurance",
-			subheader="Discover Katalyst by Codurance, the ultimate service to empower your team, boost productivity and streamline onboarding processes. Dive into our all-encompassing suite of resources tailored to elevate your team's performance: engaging training and e-learning courses, expert technical coaching for teams, customised technical coaching programs, bespoke internal academies, and much more."
-		%}
-		{% module "katalyst_cta" path="../modules/Button.module" label="Katalyst CTA" button_type="std" %}
+		<div class="katalyst__content">
+			{% section_header "katalyst_header" 
+				heading_level="h2",
+				label="Katalyst header", 
+				header="Katalyst by Codurance",
+				subheader="Discover Katalyst by Codurance, the ultimate service to empower your team, boost productivity and streamline onboarding processes. Dive into our all-encompassing suite of resources tailored to elevate your team's performance: engaging training and e-learning courses, expert technical coaching for teams, customised technical coaching programs, bespoke internal academies, and much more."
+			%}
+			{% module "katalyst_cta" path="../modules/Button.module" label="Katalyst CTA" button_type="std" %}
+		</div>
+
+		{% module "katalyst_video" path="@hubspot/video" label="Katalyst video" extra_classes="katalyst__video" %}
     </section>
 
     <section class="section-4">

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -21,7 +21,13 @@ label: Learning and Development Page
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-    	{% dnd_section %}
+    	{% dnd_section 
+			max_width=1240,
+			padding={
+				"left": 20,
+				"right": 20
+			}
+		%}
 			{% dnd_column %}
 				{% dnd_row %}
 					{% dnd_module

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -21,13 +21,7 @@ label: Learning and Development Page
 <div class="cm-services-inner-layout type1">
   <div class="banner-section">
     {% dnd_area "dnd_banner" class='banner-area', label='Banner Section' %}
-    	{% dnd_section 
-			max_width=1240,
-			padding={
-				"left": 20,
-				"right": 20
-			}
-		%}
+    	{% dnd_section full_width=true %}
 			{% dnd_column %}
 				{% dnd_row %}
 					{% dnd_module

--- a/version_control/Codurance_September2020/templates/learning-and-development.html
+++ b/version_control/Codurance_September2020/templates/learning-and-development.html
@@ -114,11 +114,11 @@ label: Learning and Development Page
     <section class="cm-services-inner-bottom-wrap" id="get-in-touch">
       {% dnd_area "dnd_area_contact" label='Contact section' %}
 		{% dnd_section 
-			max_width=1200,
-			vertical_alignment='TOP'
+			vertical_alignment='TOP',
+			full_width=true 
 		%}
 			{% dnd_module 'sl_form'
-				path='../modules/Service-Line-Form.module'
+				path='/version_control/Codurance_September2020/modules/Service-Line-Form'
 			%}
 			{% end_dnd_module %}
 		{% end_dnd_section %}

--- a/version_control/Codurance_September2020/templates/sections/service-line-hero.html
+++ b/version_control/Codurance_September2020/templates/sections/service-line-hero.html
@@ -1,0 +1,77 @@
+<!--
+ templateType: section
+ label: Service Line Hero Section
+ description: "Initial section on Service Line pages"
+ isAvailableForNewContent: true
+-->
+
+{% dnd_section 
+    background_linear_gradient={
+        "direction": "to bottom",
+        "colors": [
+            "#0F0F0F",
+            "#59BCCC"
+        ]
+    },
+    full_width=true 
+%}
+    {% dnd_column %}
+        {% dnd_row %}
+            {% dnd_module
+                path="../../modules/Text-and-image",
+                offset=0,
+                width=12,
+                title="Learning & Development",
+                image_field={ 
+                    src:"https://www.codurance.com/hubfs/Service%20Line%20Pages/06_Learning%20and%20development/LD-illu-hero.png"
+                }
+            %}
+                {% module_attribute "description_text" %}
+                    <p>Improve the skills of your teams and promote their technical excellence, to achieve better results in your business.</p>
+                {% end_module_attribute %}
+            {% end_dnd_module %}
+        {% end_dnd_row %}
+
+        {% dnd_row %}
+            {% dnd_module
+                path="@hubspot/section_header",
+                offset=0,
+                width=12,
+                header="Empower your technology teams with focused training from our world class experts",
+                heading_level="h2",
+                subheader="Enhance your team’s skillset with our industry leading training courses. We create bespoke training plans adapted to your business needs."
+            %}
+            {% end_dnd_module %}
+        {% end_dnd_row %}
+
+        {% dnd_row %}
+            {% dnd_module
+                path="../../modules/Course-Cards",
+                offset=0,
+                width=12
+            %}
+            {% end_dnd_module %}
+        {% end_dnd_row %}
+
+        {% dnd_row %}
+            {% dnd_module
+                path="../../modules/Clients-Logos",
+                offset=0,
+                width=12,
+                logos_group=[ {
+                    "logo" : {
+                        "alt" : "Envoy-logo",
+                        "height" : 190,
+                        "loading" : "lazy",
+                        "max_height" : 190,
+                        "max_width" : 579,
+                        "size_type" : "auto",
+                        "src" : "https://14557846.fs1.hubspotusercontent-na1.net/hubfs/14557846/Imported%20sitepage%20images/Envoy-logo.png",
+                        "width" : 579
+                    }
+                } ]
+            %}
+            {% end_dnd_module %}
+        {% end_dnd_row %}
+    {% end_dnd_column %}
+{% end_dnd_section %}


### PR DESCRIPTION
Creating a new template to revamp the formerly Training Service Line now _Learning and development_. We had:

* Modified and de-structured the first section into a drag and drop module
* Create a new courses module 
* Include a new section to point to the Katalyst by Codurance microsite.
* Update all styles to match the design specs
