### PR TITLE
Fix/learning-and-development/course-pages/footer-overlap

### DIFF
--- a/version_control/Codurance_September2020/css/_header.css
+++ b/version_control/Codurance_September2020/css/_header.css
@@ -17,7 +17,7 @@ header.header {
   z-index: 100;
 }
 
-.body-wrapper > div:first-child,
+.body-wrapper > div:first-child[data-global-resource-path],
 header.header {
   --header-height: 71px;
   height: var(--header-height);

--- a/version_control/Codurance_September2020/templates/training-inner-pages.html
+++ b/version_control/Codurance_September2020/templates/training-inner-pages.html
@@ -7,30 +7,27 @@ label: Training Inner Page
 
 {{ require_css(get_asset_url("../css/pages/training-inner.css")) }}
 
-
-{% block header %}
-{% endblock header %}
 {% block body %}
-<div class="container">
-  <div class="banner-section">
-    {% dnd_area "DND_banner" class='', label='Banner Section' %}
-    {% dnd_section full_width=true %}
-    {% dnd_module path='../modules/Crafting code banner', width=12, offset=0, label="" %}
-    {% end_dnd_module %}
-    {% end_dnd_section %}
-    {% end_dnd_area %}
-  </div>
-  <main class="body-container-wrapper">
-    {% dnd_area "dnd_area1" class='course-details-section', label='Section 1' %}
-    {% end_dnd_area %}
-    {% dnd_area "dnd_area2" class='course-instructor-bio-section', label='Section 2' %}
-    {% end_dnd_area %}
-    {% dnd_area "dnd_area3" class='client-logo-section', label='Section 2' %}
-    {% end_dnd_area %}
-    <div class="bottom-container" id="get-in-touch">
-      {% dnd_area "dnd_area4" class='form-section', label='Section 4' %}
+  <div class="container">
+    <div class="banner-section">
+      {% dnd_area "DND_banner" class='', label='Banner Section' %}
+      {% dnd_section full_width=true %}
+      {% dnd_module path='../modules/Crafting code banner', width=12, offset=0, label="" %}
+      {% end_dnd_module %}
+      {% end_dnd_section %}
       {% end_dnd_area %}
     </div>
-  </main>
-</div>
+    <main class="body-container-wrapper">
+      {% dnd_area "dnd_area1" class='course-details-section', label='Section 1' %}
+      {% end_dnd_area %}
+      {% dnd_area "dnd_area2" class='course-instructor-bio-section', label='Section 2' %}
+      {% end_dnd_area %}
+      {% dnd_area "dnd_area3" class='client-logo-section', label='Section 3' %}
+      {% end_dnd_area %}
+      <div class="bottom-container" id="get-in-touch">
+        {% dnd_area "dnd_area4" class='form-section', label='Section 4' %}
+        {% end_dnd_area %}
+      </div>
+    </main>
+  </div>
 {% endblock body %}


### PR DESCRIPTION
Adjustments to Learning & Development individual course pages in order to avoid the footer from overlapping on the content in mobile