### PR TITLE
Feature/module/upcoming-events/city-name-for-in-person-events

### DIFF
--- a/version_control/Codurance_September2020/css/card-slider.css
+++ b/version_control/Codurance_September2020/css/card-slider.css
@@ -344,6 +344,12 @@
   left: {{label_position}};
 }
 
+.card-slider-item__label--city {
+  right: {{label_position}};
+  background-color: var(--mid-gray);
+  color: white;
+}
+
 .card-slider-item__label--duration {
   right: {{label_position}};
 }

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/fields.json
@@ -17,15 +17,6 @@
   "type" : "text",
   "default" : "Upcoming Events"
 }, {
-  "id" : "68cd05f2-138b-2241-0169-db614bd61760",
-  "name" : "translation_information_text",
-  "label" : "Translation Information Text",
-  "required" : false,
-  "locked" : false,
-  "display" : "checkbox",
-  "type" : "boolean",
-  "default" : false
-}, {
   "id" : "35683103-66da-e088-217c-68482b20fa30",
   "name" : "newsletter_text_field",
   "label" : "Newsletter title",

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -87,6 +87,13 @@
                 >
                   {{ event.type.name }}
                 </small>
+                {% if event.city && event.type.name == "In person" %}
+                  <small
+                    class="card-slider-item__label card-slider-item__label--city"
+                  >
+                    {{ event.city }}
+                  </small>
+                {% endif %}
               {% endif %}
             </div>
             <div class="card-slider-item__text-container">

--- a/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
+++ b/version_control/Codurance_September2020/modules/Upcoming Events Listing.module/module.html
@@ -72,12 +72,6 @@
             </svg>
           </button>
         </div>
-        {% if module.translation_information_text %}
-          <div class="card-slider__translation-info">
-            <i class="las la-info-circle"></i>
-            <small>Nuestros eventos son, en su mayoría, en inglés. Por eso estás viendo sus títulos y descripciones en este idioma.</small>
-          </div>
-        {% endif %}
       </div>
       <div class="card-slider-results" data-upcoming-card-track>
         {% for event in upcomingEvents %}
@@ -92,7 +86,7 @@
                   class="card-slider-item__label card-slider-item__label--type"
                 >
                   {{ event.type.name }}
-              </small>
+                </small>
               {% endif %}
             </div>
             <div class="card-slider-item__text-container">


### PR DESCRIPTION
- Create label to display city name for in person events
- Remove unused translation information text field from upcoming events module