### PR TITLE
Remove usability of secondary menu module from dnd

### DIFF
--- a/version_control/Codurance_September2020/modules/secondary-menu.module/meta.json
+++ b/version_control/Codurance_September2020/modules/secondary-menu.module/meta.json
@@ -10,8 +10,8 @@
   "global" : false,
   "master_language" : "en",
   "icon" : "fontawesome-5.14.0:Compass",
-  "host_template_types" : [ "PAGE", "BLOG_LISTING", "BLOG_POST" ],
+  "host_template_types" : [ "PAGE" ],
   "module_id" : 69712369971,
   "label" : "Secondary Menu",
-  "is_available_for_new_content" : true
+  "is_available_for_new_content" : false
 }


### PR DESCRIPTION
Previously the secondary menu could be used on any drag and drop section, but it doesn't work well there since it cannot be used as a sticky menu and doesn't look great layout-wise since it's horizontal on desktop and doesn't have full-width.