### PR TITLE
Create conditional to hide default pop-up newsletter banner

### DIFF
--- a/version_control/Codurance_September2020/templates/blog-post.html
+++ b/version_control/Codurance_September2020/templates/blog-post.html
@@ -311,13 +311,14 @@ label: Blog Post
     no_wrapper=True
   %}
 
-  {% module "newsletter_exit_popup"
-    path="../modules/Newsletter Exit Popup.module",
-    label="Newsletter exit popup", 
-    title="{{ newsletter_copy.pending.header }}",
-    subtitle="{{ newsletter_copy.pending.text }}",
-    sign_up_form={ form_id: "{{ newsletter_copy.form_id }}", message: "{{ newsletter_copy.success_text }}" },
-    no_wrapper=True
-  %}
-
-  {% endblock body %}
+  {% if locale == 'en' || locale == 'pt' %}
+    {% module "newsletter_exit_popup"
+      path="../modules/Newsletter Exit Popup.module",
+      label="Newsletter exit popup", 
+      title="{{ newsletter_copy.pending.header }}",
+      subtitle="{{ newsletter_copy.pending.text }}",
+      sign_up_form={ form_id: "{{ newsletter_copy.form_id }}", message: "{{ newsletter_copy.success_text }}" },
+      no_wrapper=True
+    %}
+  {% endif %}
+{% endblock body %}


### PR DESCRIPTION
This request came from the ES marketing team to promote the Katalyst by codurance website. The intention is to show a different pop up banner on the blog post, so we hide the default one and we used the newly CTA popup [banners from Hubspot](https://knowledge.hubspot.com/ctas/create-calls-to-action)