### PR TITLE
Feature/add-color-capability-to-client-logos

### DIFF
--- a/version_control/Codurance_September2020/css/modules/clients-logos.css
+++ b/version_control/Codurance_September2020/css/modules/clients-logos.css
@@ -13,7 +13,6 @@
 }
 
 .client-logos__logos-group{
-    filter: contrast(0%);
     margin: 1.5em 0;
     display: grid;
     gap: 1em;

--- a/version_control/Codurance_September2020/modules/Clients-Logos.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Clients-Logos.module/fields.json
@@ -1,212 +1,236 @@
-[ {
-  "id" : "6a7d51e7-385e-fb75-c9aa-cb05434e702c",
-  "name" : "clients_headline",
-  "display_width" : null,
-  "label" : "Clients headline",
-  "required" : false,
-  "locked" : false,
-  "validation_regex" : "",
-  "allow_new_line" : false,
-  "show_emoji_picker" : false,
-  "type" : "text",
-  "default" : "You’re in good company"
-}, {
-  "id" : "699b6c22-941a-425d-3bee-06ecdf5275ea",
-  "name" : "logos_group",
-  "display_width" : null,
-  "label" : "Logos group",
-  "required" : false,
-  "locked" : false,
-  "occurrence" : {
-    "min" : 1,
-    "max" : null,
-    "sorting_label_field" : null,
-    "default" : 1
+[
+  {
+    "id": "6a7d51e7-385e-fb75-c9aa-cb05434e702c",
+    "name": "clients_headline",
+    "display_width": null,
+    "label": "Clients headline",
+    "required": false,
+    "locked": false,
+    "validation_regex": "",
+    "allow_new_line": false,
+    "show_emoji_picker": false,
+    "type": "text",
+    "default": "You’re in good company"
   },
-  "children" : [ {
-    "id" : "e5a985f1-c410-73ca-fca4-933dd3b7d4c6",
-    "name" : "logo",
-    "display_width" : null,
-    "label" : "Logo",
-    "required" : false,
-    "locked" : false,
-    "responsive" : true,
-    "resizable" : true,
-    "show_loading" : false,
-    "type" : "image",
-    "default" : {
-      "size_type" : "auto",
-      "src" : "",
-      "alt" : null,
-      "loading" : "lazy"
-    }
-  } ],
-  "tab" : "CONTENT",
-  "expanded" : false,
-  "type" : "group",
-  "default" : [ {
-    "logo" : {
-      "size_type" : "auto",
-      "src" : "",
-      "alt" : null,
-      "loading" : "lazy"
-    }
-  } ]
-}, {
-  "id" : "button_type",
-  "name" : "button_type",
-  "display_width" : null,
-  "label" : "Button Type",
-  "required" : false,
-  "locked" : false,
-  "display" : "select",
-  "choices" : [ [ "std", "Standard" ], [ "cta", "CTA" ] ],
-  "multiple" : false,
-  "reordering_enabled" : true,
-  "preset" : null,
-  "type" : "choice"
-}, {
-  "id" : "link_field",
-  "name" : "link_field",
-  "display_width" : null,
-  "label" : "Link",
-  "required" : false,
-  "locked" : false,
-  "visibility" : {
-    "controlling_field" : "button_type",
-    "controlling_field_path" : null,
-    "controlling_value_regex" : "std",
-    "property" : null,
-    "operator" : "EQUAL",
-    "access" : null
-  },
-  "supported_types" : [ "EXTERNAL", "CONTENT", "BLOG" ],
-  "show_advanced_rel_options" : false,
-  "type" : "link",
-  "default" : {
-    "url" : {
-      "content_id" : null,
-      "type" : "EXTERNAL",
-      "href" : ""
+  {
+    "id": "699b6c22-941a-425d-3bee-06ecdf5275ea",
+    "name": "logos_group",
+    "display_width": null,
+    "label": "Logos group",
+    "required": false,
+    "locked": false,
+    "occurrence": {
+      "min": 1,
+      "max": null,
+      "sorting_label_field": null,
+      "default": 1
     },
-    "open_in_new_tab" : false,
-    "no_follow" : false
-  }
-}, {
-  "id" : "text_field",
-  "name" : "text_field",
-  "display_width" : null,
-  "label" : "Text",
-  "required" : false,
-  "locked" : false,
-  "validation_regex" : "",
-  "visibility" : {
-    "controlling_field" : "button_type",
-    "controlling_field_path" : null,
-    "controlling_value_regex" : "std",
-    "property" : null,
-    "operator" : "EQUAL",
-    "access" : null
+    "children": [
+      {
+        "id": "e5a985f1-c410-73ca-fca4-933dd3b7d4c6",
+        "name": "logo",
+        "display_width": null,
+        "label": "Logo",
+        "required": false,
+        "locked": false,
+        "responsive": true,
+        "resizable": true,
+        "show_loading": false,
+        "type": "image",
+        "default": {
+          "size_type": "auto",
+          "src": "",
+          "alt": null,
+          "loading": "lazy"
+        }
+      }
+    ],
+    "tab": "CONTENT",
+    "expanded": false,
+    "type": "group",
+    "default": [
+      {
+        "logo": {
+          "size_type": "auto",
+          "src": "",
+          "alt": null,
+          "loading": "lazy"
+        }
+      }
+    ]
   },
-  "allow_new_line" : false,
-  "show_emoji_picker" : false,
-  "type" : "text",
-  "default" : "Button"
-}, {
-  "id" : "bookmark_id",
-  "name" : "bookmark_id",
-  "display_width" : null,
-  "label" : "Bookmark id",
-  "required" : false,
-  "locked" : false,
-  "validation_regex" : "",
-  "visibility" : {
-    "controlling_field" : "button_type",
-    "controlling_field_path" : null,
-    "controlling_value_regex" : "std",
-    "property" : null,
-    "operator" : "EQUAL",
-    "access" : null
+  {
+    "id": "button_type",
+    "name": "button_type",
+    "display_width": null,
+    "label": "Button Type",
+    "required": false,
+    "locked": false,
+    "display": "select",
+    "choices": [
+      ["std", "Standard"],
+      ["cta", "CTA"]
+    ],
+    "multiple": false,
+    "reordering_enabled": true,
+    "preset": null,
+    "type": "choice"
   },
-  "allow_new_line" : false,
-  "show_emoji_picker" : false,
-  "type" : "text"
-}, {
-  "id" : "module_setting",
-  "name" : "module_setting",
-  "display_width" : null,
-  "label" : "Module Setting",
-  "required" : false,
-  "locked" : false,
-  "children" : [ {
-    "id" : "custom_class",
-    "name" : "custom_class",
-    "display_width" : null,
-    "label" : "Custom Class",
-    "required" : false,
-    "locked" : false,
-    "validation_regex" : "",
-    "visibility" : {
-      "controlling_field" : "button_type",
-      "controlling_field_path" : null,
-      "controlling_value_regex" : "std",
-      "property" : null,
-      "operator" : "EQUAL",
-      "access" : null
+  {
+    "id": "link_field",
+    "name": "link_field",
+    "display_width": null,
+    "label": "Link",
+    "required": false,
+    "locked": false,
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_field_path": null,
+      "controlling_value_regex": "std",
+      "property": null,
+      "operator": "EQUAL",
+      "access": null
     },
-    "allow_new_line" : false,
-    "show_emoji_picker" : false,
-    "type" : "text",
-    "default" : ""
-  } ],
-  "tab" : "CONTENT",
-  "expanded" : false,
-  "type" : "group",
-  "default" : {
-    "custom_class" : ""
-  }
-}, {
-  "id" : "e86c5cbc-9ce1-ad62-2d66-ccc918aa1c91",
-  "name" : "style",
-  "display_width" : null,
-  "label" : "Style",
-  "required" : false,
-  "locked" : false,
-  "children" : [ {
-    "id" : "af4113dc-15ca-e052-ea1b-15936c3947cc",
-    "name" : "logo_color",
-    "display_width" : null,
-    "label" : "Logo color",
-    "required" : false,
-    "locked" : false,
-    "display" : "radio",
-    "choices" : [ [ "grey", "Grey" ], [ "color", "Full Color" ] ],
-    "multiple" : false,
-    "reordering_enabled" : true,
-    "preset" : null,
-    "type" : "choice",
-    "default" : "grey"
-  } ],
-  "tab" : "STYLE",
-  "expanded" : false,
-  "type" : "group",
-  "default" : {
-    "logo_color" : "grey"
-  }
-}, {
-  "id" : "09b06862-a1a7-717e-f34a-92a6894f3b44",
-  "name" : "clients_cta",
-  "display_width" : null,
-  "label" : "Clients CTA",
-  "required" : false,
-  "locked" : false,
-  "visibility" : {
-    "controlling_field" : "button_type",
-    "controlling_field_path" : null,
-    "controlling_value_regex" : "cta",
-    "property" : null,
-    "operator" : "EQUAL",
-    "access" : null
+    "supported_types": ["EXTERNAL", "CONTENT", "BLOG"],
+    "show_advanced_rel_options": false,
+    "type": "link",
+    "default": {
+      "url": {
+        "content_id": null,
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    }
   },
-  "type" : "cta"
-} ]
+  {
+    "id": "text_field",
+    "name": "text_field",
+    "display_width": null,
+    "label": "Text",
+    "required": false,
+    "locked": false,
+    "validation_regex": "",
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_field_path": null,
+      "controlling_value_regex": "std",
+      "property": null,
+      "operator": "EQUAL",
+      "access": null
+    },
+    "allow_new_line": false,
+    "show_emoji_picker": false,
+    "type": "text",
+    "default": "Button"
+  },
+  {
+    "id": "bookmark_id",
+    "name": "bookmark_id",
+    "display_width": null,
+    "label": "Bookmark id",
+    "required": false,
+    "locked": false,
+    "validation_regex": "",
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_field_path": null,
+      "controlling_value_regex": "std",
+      "property": null,
+      "operator": "EQUAL",
+      "access": null
+    },
+    "allow_new_line": false,
+    "show_emoji_picker": false,
+    "type": "text"
+  },
+  {
+    "id": "module_setting",
+    "name": "module_setting",
+    "display_width": null,
+    "label": "Module Setting",
+    "required": false,
+    "locked": false,
+    "children": [
+      {
+        "id": "custom_class",
+        "name": "custom_class",
+        "display_width": null,
+        "label": "Custom Class",
+        "required": false,
+        "locked": false,
+        "validation_regex": "",
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_field_path": null,
+          "controlling_value_regex": "std",
+          "property": null,
+          "operator": "EQUAL",
+          "access": null
+        },
+        "allow_new_line": false,
+        "show_emoji_picker": false,
+        "type": "text",
+        "default": ""
+      }
+    ],
+    "tab": "CONTENT",
+    "expanded": false,
+    "type": "group",
+    "default": {
+      "custom_class": ""
+    }
+  },
+  {
+    "id": "e86c5cbc-9ce1-ad62-2d66-ccc918aa1c91",
+    "name": "style",
+    "display_width": null,
+    "label": "Style",
+    "required": false,
+    "locked": false,
+    "children": [
+      {
+        "id": "af4113dc-15ca-e052-ea1b-15936c3947cc",
+        "name": "logo_color",
+        "display_width": null,
+        "label": "Logo color",
+        "required": false,
+        "locked": false,
+        "display": "radio",
+        "choices": [
+          ["grey", "Grey"],
+          ["color", "Full Color"]
+        ],
+        "multiple": false,
+        "reordering_enabled": true,
+        "preset": null,
+        "type": "choice",
+        "default": "grey"
+      }
+    ],
+    "tab": "STYLE",
+    "expanded": false,
+    "type": "group",
+    "default": {
+      "logo_color": "grey"
+    }
+  },
+  {
+    "id": "09b06862-a1a7-717e-f34a-92a6894f3b44",
+    "name": "clients_cta",
+    "display_width": null,
+    "label": "Clients CTA",
+    "required": false,
+    "locked": false,
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_field_path": null,
+      "controlling_value_regex": "cta",
+      "property": null,
+      "operator": "EQUAL",
+      "access": null
+    },
+    "type": "cta"
+  }
+]

--- a/version_control/Codurance_September2020/modules/Clients-Logos.module/fields.json
+++ b/version_control/Codurance_September2020/modules/Clients-Logos.module/fields.json
@@ -1,6 +1,7 @@
 [ {
   "id" : "6a7d51e7-385e-fb75-c9aa-cb05434e702c",
   "name" : "clients_headline",
+  "display_width" : null,
   "label" : "Clients headline",
   "required" : false,
   "locked" : false,
@@ -12,6 +13,7 @@
 }, {
   "id" : "699b6c22-941a-425d-3bee-06ecdf5275ea",
   "name" : "logos_group",
+  "display_width" : null,
   "label" : "Logos group",
   "required" : false,
   "locked" : false,
@@ -19,11 +21,12 @@
     "min" : 1,
     "max" : null,
     "sorting_label_field" : null,
-    "default" : null
+    "default" : 1
   },
   "children" : [ {
     "id" : "e5a985f1-c410-73ca-fca4-933dd3b7d4c6",
     "name" : "logo",
+    "display_width" : null,
     "label" : "Logo",
     "required" : false,
     "locked" : false,
@@ -58,6 +61,9 @@
   "locked" : false,
   "display" : "select",
   "choices" : [ [ "std", "Standard" ], [ "cta", "CTA" ] ],
+  "multiple" : false,
+  "reordering_enabled" : true,
+  "preset" : null,
   "type" : "choice"
 }, {
   "id" : "link_field",
@@ -68,10 +74,11 @@
   "locked" : false,
   "visibility" : {
     "controlling_field" : "button_type",
+    "controlling_field_path" : null,
     "controlling_value_regex" : "std",
+    "property" : null,
     "operator" : "EQUAL",
-    "access" : null,
-    "hidden_subfields" : null
+    "access" : null
   },
   "supported_types" : [ "EXTERNAL", "CONTENT", "BLOG" ],
   "show_advanced_rel_options" : false,
@@ -95,10 +102,11 @@
   "validation_regex" : "",
   "visibility" : {
     "controlling_field" : "button_type",
+    "controlling_field_path" : null,
     "controlling_value_regex" : "std",
+    "property" : null,
     "operator" : "EQUAL",
-    "access" : null,
-    "hidden_subfields" : null
+    "access" : null
   },
   "allow_new_line" : false,
   "show_emoji_picker" : false,
@@ -114,10 +122,11 @@
   "validation_regex" : "",
   "visibility" : {
     "controlling_field" : "button_type",
+    "controlling_field_path" : null,
     "controlling_value_regex" : "std",
+    "property" : null,
     "operator" : "EQUAL",
-    "access" : null,
-    "hidden_subfields" : null
+    "access" : null
   },
   "allow_new_line" : false,
   "show_emoji_picker" : false,
@@ -139,10 +148,11 @@
     "validation_regex" : "",
     "visibility" : {
       "controlling_field" : "button_type",
+      "controlling_field_path" : null,
       "controlling_value_regex" : "std",
+      "property" : null,
       "operator" : "EQUAL",
-      "access" : null,
-      "hidden_subfields" : null
+      "access" : null
     },
     "allow_new_line" : false,
     "show_emoji_picker" : false,
@@ -156,17 +166,47 @@
     "custom_class" : ""
   }
 }, {
+  "id" : "e86c5cbc-9ce1-ad62-2d66-ccc918aa1c91",
+  "name" : "style",
+  "display_width" : null,
+  "label" : "Style",
+  "required" : false,
+  "locked" : false,
+  "children" : [ {
+    "id" : "af4113dc-15ca-e052-ea1b-15936c3947cc",
+    "name" : "logo_color",
+    "display_width" : null,
+    "label" : "Logo color",
+    "required" : false,
+    "locked" : false,
+    "display" : "radio",
+    "choices" : [ [ "grey", "Grey" ], [ "color", "Full Color" ] ],
+    "multiple" : false,
+    "reordering_enabled" : true,
+    "preset" : null,
+    "type" : "choice",
+    "default" : "grey"
+  } ],
+  "tab" : "STYLE",
+  "expanded" : false,
+  "type" : "group",
+  "default" : {
+    "logo_color" : "grey"
+  }
+}, {
   "id" : "09b06862-a1a7-717e-f34a-92a6894f3b44",
   "name" : "clients_cta",
+  "display_width" : null,
   "label" : "Clients CTA",
   "required" : false,
   "locked" : false,
   "visibility" : {
     "controlling_field" : "button_type",
+    "controlling_field_path" : null,
     "controlling_value_regex" : "cta",
+    "property" : null,
     "operator" : "EQUAL",
-    "access" : null,
-    "hidden_subfields" : null
+    "access" : null
   },
   "type" : "cta"
-}  ]
+} ]

--- a/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
+++ b/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
@@ -2,18 +2,15 @@
 
 {{ require_css(get_asset_url("../../css/modules/clients-logos.css")) }}
 
-{% require_css %}
+
   <style>
-    {% scope_css %}
       .client-logos__logos-group{
         {% if module.style.logo_color == "grey" %}
-        filter: contrast(0);
+        	filter: contrast(0);
         {% endif %}    
       }
-    {% end_scope_css %}
   </style>
 
-{% end_require_css %}
 
 <div class="client-logos__content">
 	<div class="client-logos__headline">

--- a/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
+++ b/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
@@ -3,13 +3,17 @@
 {{ require_css(get_asset_url("../../css/modules/clients-logos.css")) }}
 
 
+{% require_css }
   <style>
+    {% scope_css }
       .client-logos__logos-group{
         {% if module.style.logo_color == "grey" %}
         	filter: contrast(0);
         {% endif %}    
       }
+    {% end_scope_css }
   </style>
+{% require_css }
 
 
 <div class="client-logos__content">

--- a/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
+++ b/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
@@ -2,6 +2,19 @@
 
 {{ require_css(get_asset_url("../../css/modules/clients-logos.css")) }}
 
+{% require_css %}
+  <style>
+    {% scope_css %}
+      .client-logos__logos-group{
+        {% if module.style.logo_color == "grey" %}
+        filter: contrast(0);
+        {% endif %}    
+      }
+    {% end_scope_css %}
+  </style>
+
+{% end_require_css %}
+
 <div class="client-logos__content">
 	<div class="client-logos__headline">
 		<h2>{{ module.clients_headline }}</h2>

--- a/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
+++ b/version_control/Codurance_September2020/modules/Clients-Logos.module/module.html
@@ -3,17 +3,17 @@
 {{ require_css(get_asset_url("../../css/modules/clients-logos.css")) }}
 
 
-{% require_css }
+{% require_css %}
   <style>
-    {% scope_css }
+    {% scope_css %}
       .client-logos__logos-group{
         {% if module.style.logo_color == "grey" %}
         	filter: contrast(0);
         {% endif %}    
       }
-    {% end_scope_css }
+    {% end_scope_css %}
   </style>
-{% require_css }
+{% end_require_css %}
 
 
 <div class="client-logos__content">

--- a/version_control/Codurance_September2020/modules/Thumbnails-Grid.module/module.html
+++ b/version_control/Codurance_September2020/modules/Thumbnails-Grid.module/module.html
@@ -52,8 +52,8 @@
         }
 
         {% set overlay_background_color = 
-            "rgba({{ module.styles.grid_images.overlay.background.color.color|convert_rgb }},
-            {{ module.styles.grid_images.overlay.background.color.opacity/100 }});" 
+            "linear-gradient(120deg, rgba({{ module.styles.grid_images.overlay.background.color.color|convert_rgb }},
+            {{ module.styles.grid_images.overlay.background.color.opacity/100 }}) 30% , transparent );" 
         %}
 
         .hs-image__grid__item__overlay {
@@ -64,7 +64,7 @@
                 border-radius: {{ border_radius }};
             {% endif %}
             {% if module.styles.grid_images.overlay.background.color.color %}
-                background-color: {{ overlay_background_color }}
+                background: {{ overlay_background_color }}
             {% endif %}
             {% if module.styles.grid_images.overlay.background.blend_mode %}
                 mix-blend-mode: hard-light;

--- a/version_control/Codurance_September2020/templates/home-v2.html
+++ b/version_control/Codurance_September2020/templates/home-v2.html
@@ -41,7 +41,7 @@ label: Home Page version 2
   <section class="client-logos">
     {% module 'clients logos' 
         path='../modules/Clients-Logos.module'
-        label="Clients logos Section" no_wrapper=True %}
+        label="Clients logos Section"%}
   </section>
   <section class="software-consultancy">
     {% module 'Text and image' 

--- a/version_control/Codurance_September2020/templates/industries-overview-page.html
+++ b/version_control/Codurance_September2020/templates/industries-overview-page.html
@@ -66,7 +66,6 @@ label: Industries Overview
 <section class="clients-logos region lateral-spacing">
   {% module "clients_logos"
     path="../modules/Clients-Logos.module" label="Clients logos"
-    no_wrapper=True 
   %}
 </section>
 


### PR DESCRIPTION
Update a couple of features on 2 modules:

* Have the option to set color to client logos on the module.
* Change the overlay color on the industries grid overalay to a subtle linear gradient. User still can choose the color.