### PR TITLE
Fix/insights-overview/upcoming-events-language

### DIFF
--- a/version_control/Codurance_September2020/modules/Simple-Card.module/module.html
+++ b/version_control/Codurance_September2020/modules/Simple-Card.module/module.html
@@ -7,14 +7,15 @@
 
 {% if cards_type_selected == "hubdb" %}
     {% set upcomingEventsFilter = ("&orderBy=datetime" + "&datetime__gt=" + local_dt|unixtimestamp + "&limit=3") %}
-    {% set isEventEnglish = ("&language=English") %}
+    {% set setEnglishEvents = ("&language=English") %}
+    {% set setSpanishEvents = ("&language=Spanish") %}
 
     {% set list = [] %}
 
-    {% if locale == "en" or locale == "pt" %}
-        {% set list = hubdb_table_rows(module.hubdb, upcomingEventsFilter + isEventEnglish) %}
+    {% if locale == "es" %}
+        {% set list = hubdb_table_rows(module.hubdb, upcomingEventsFilter + setSpanishEvents) %}
     {% else %}
-        {% set list = hubdb_table_rows(module.hubdb, upcomingEventsFilter) %}
+        {% set list = hubdb_table_rows(module.hubdb, upcomingEventsFilter + setEnglishEvents) %}
     {% endif %} 
 
     {% for item in list %}

--- a/version_control/Codurance_September2020/templates/insights-overview-page.html
+++ b/version_control/Codurance_September2020/templates/insights-overview-page.html
@@ -36,7 +36,9 @@
 
   <section class="upcoming-events">
     <div class="page-center">
-      <h2 class="upcoming-events__title lateral-spacing">{% text 'events-title' label="Upcoming Events Title" no_wrapper=True %}</h2>
+      <h2 class="upcoming-events__title lateral-spacing">
+        {% text 'events-title' label="Upcoming Events Title" no_wrapper=True %}
+      </h2>
       {% module 'event-cards' path='../modules/Simple-Card.module'
       label="Upcoming Event Cards" no_wrapper=True %}
 


### PR DESCRIPTION
The marketing spanish team requested to have only upcoming events in Spanish, so we updated the filter accordingly.

For further information , have a look [on the request](https://codurance-unit.monday.com/boards/2048184077/pulses/5967737152)