### PR TITLE
Update/insights-podcasts/optimize-load-time

### DIFF
--- a/version_control/Codurance_September2020/modules/Latest-PodBean-Episode.module/module.js
+++ b/version_control/Codurance_September2020/modules/Latest-PodBean-Episode.module/module.js
@@ -1,24 +1,15 @@
 "use strict";
 
 (async () => {
-  const podcastEpisodes = await fetchPodcastEpisodes();
-  const latestEpisode = getLatestEpisode(podcastEpisodes);
-  setLatestEpisodeOnModule(latestEpisode);
+  const latestPodcastEpisode = await fetchLatestPodcastEpisode();
+  setLatestEpisodeOnModule(latestPodcastEpisode);
   displayModule();
 
-  async function fetchPodcastEpisodes() {
-    const urlEndpoint = "/_hcms/api/fetch_podcast_episodes";
+  async function fetchLatestPodcastEpisode() {
+    const urlEndpoint = "/_hcms/api/fetch_latest_codurance_talks_episode";
     const response = await fetch(urlEndpoint);
-    const podcastEpisodes = await response.json();
-    return podcastEpisodes;
-  }
-
-  function getLatestEpisode(podcastEpisodes) {
-    podcastEpisodes.sort(
-      (episodeA, episodeB) => episodeB.publish_time - episodeA.publish_time
-    );
-
-    return podcastEpisodes[0];
+    const podcastEpisode = await response.json();
+    return podcastEpisode;
   }
 
   function setLatestEpisodeOnModule(latestEpisode) {

--- a/version_control/Codurance_September2020/serverless/podcast-episodes.functions/fetchLatestCoduranceTalksEpisode.js
+++ b/version_control/Codurance_September2020/serverless/podcast-episodes.functions/fetchLatestCoduranceTalksEpisode.js
@@ -1,0 +1,43 @@
+exports.main = async (context, sendResponse) => {
+  const podcastToken = await requestPodcastToken();
+  const podcastEpisode = await fetchLatestPodcastEpisode(podcastToken);
+  const OneDaySeconds = 86400;
+
+  sendResponse({
+    body: podcastEpisode,
+    headers: {
+      "Cache-Control": `max-age=${OneDaySeconds}`
+    },
+    statusCode: 200
+  });
+
+  async function requestPodcastToken() {
+    const { clientID, clientSecret } = context.secrets;
+    const authorizationString = Buffer.from(
+      `${clientID}:${clientSecret}`
+    ).toString("base64");
+    const coduranceTalksID = "L6nj3tJrcwN";
+
+    const headers = new Headers();
+    headers.append("Authorization", `Basic ${authorizationString}`);
+    headers.append("Content-Type", "application/x-www-form-urlencoded");
+
+    const response = await fetch("https://api.podbean.com/v1/oauth/token", {
+      method: "POST",
+      headers: headers,
+      body: `grant_type=client_credentials&podcast_id=${coduranceTalksID}`
+    });
+    const podcastToken = await response.json();
+
+    return podcastToken.access_token;
+  }
+
+  async function fetchLatestPodcastEpisode(token) {
+    const response = await fetch(
+      `https://api.podbean.com/v1/episodes?access_token=${token}&limit=1`
+    );
+    const podcastEpisode = await response.json();
+
+    return podcastEpisode.episodes[0];
+  }
+};

--- a/version_control/Codurance_September2020/serverless/podcast-episodes.functions/fetchPodcastEpisodes.js
+++ b/version_control/Codurance_September2020/serverless/podcast-episodes.functions/fetchPodcastEpisodes.js
@@ -1,8 +1,13 @@
 exports.main = async (context, sendResponse) => {
   const podcastTokens = await requestPodcastTokens();
   const podcastEpisodes = await fetchPodcastsEpisodesByTokens(podcastTokens);
+  const OneDaySeconds = 86400;
+
   sendResponse({
     body: podcastEpisodes,
+    headers: {
+      "Cache-Control": `max-age=${OneDaySeconds}`
+    },
     statusCode: 200
   });
 

--- a/version_control/Codurance_September2020/serverless/podcast-episodes.functions/serverless.json
+++ b/version_control/Codurance_September2020/serverless/podcast-episodes.functions/serverless.json
@@ -6,9 +6,13 @@
     "clientSecret"
   ],
   "endpoints": {
+    "fetch_latest_codurance_talks_episode": {
+      "method": "GET",
+      "file": "fetchLatestCoduranceTalksEpisode.js"
+    },
     "fetch_podcast_episodes": {
      "method": "GET",
      "file": "fetchPodcastEpisodes.js"
-   }
+    }
   }
 }


### PR DESCRIPTION
Optimization effort on the Insights Podcasts page, since the podcasts took a lot of time to load. The main points of improvement are the following:
- Create new endpoint on podcast-related Hubspot serverless functions to only load the latest episode of the Codurance Talks podcast. This allows to minify the load of the latest episode section at the top of the page
- Add HTTP cache to the responses of both podcast-related Hubspot serverless function endpoints. From now on this responses will be stored for 1 day and served to all users