### PR TITLE
Update/template/change-sqa-template-to-assessment-and-add-new-features

### DIFF
--- a/version_control/Codurance_September2020/css/pages/assessment.css
+++ b/version_control/Codurance_September2020/css/pages/assessment.css
@@ -80,6 +80,11 @@ section.responsive-page-width {
 {% call utils.small() %}
     .hero .text-and-image__container {
         padding-top: unset;
+        margin-top: -2.5rem;
+    }
+
+    .hero .text-and-image__container img {
+        transform: translate(10%);
     }
 {% endcall %}
 

--- a/version_control/Codurance_September2020/css/pages/assessment.css
+++ b/version_control/Codurance_September2020/css/pages/assessment.css
@@ -47,11 +47,23 @@ section.responsive-page-width {
     height: 8.5rem;
 }
 
-{% call utils.large_and_extra_large() %}
+{% call utils.medium_large_and_extra_large() %}
     .hero .text-and-image__copy {
-        max-width: 35rem;
+        max-width: 57.5%;
+        text-wrap: balance;    
     }
 
+    .hero .text-and-image__image > img {
+        object-fit: cover;
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        max-width: 42.5%;
+    }
+{% endcall %}
+
+{% call utils.large_and_extra_large() %}
     .hero .text-and-image__copy p {
         {{ utils.freed() }}
         font-weight: var(--light-font-weight);

--- a/version_control/Codurance_September2020/css/pages/assessment.css
+++ b/version_control/Codurance_September2020/css/pages/assessment.css
@@ -77,6 +77,12 @@ section.responsive-page-width {
     }
 {% endcall %}
 
+{% call utils.small() %}
+    .hero .text-and-image__container {
+        padding-top: unset;
+    }
+{% endcall %}
+
 /* Solution section */
 .solution {
     {{ utils.white_to_tango() }}

--- a/version_control/Codurance_September2020/css/pages/assessment.css
+++ b/version_control/Codurance_September2020/css/pages/assessment.css
@@ -1,11 +1,11 @@
 {% import '../utils/utils.css' as utils %}
 
+/* General styles */
 :root {
   scroll-behavior: smooth;
   --card-img-height: 6rem;
 }
 
-/* General styles */
 .section-header h2 {
     {{ utils.freed() }}
     font-weight: var(--heavy-font-weight);
@@ -17,20 +17,34 @@ section.responsive-page-width {
     margin-inline: auto;
 }
 
+.gradient-container {
+    height: 19rem;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+}
+
 /* Hero section */
 .hero {
     {{ utils.slate_to_woodsmoke() }}
     color: white;
+    position: relative;
 }
 
 .hero .text-and-image__container {
     max-width: var(--content-max-width);
     justify-content: flex-start;
+    z-index: 1;
+    position: relative;
 }
 
 .hero .text-and-image__copy p {
     {{ utils.base() }}
     font-weight: var(--light-font-weight);
+}
+
+.hero .gradient-container {
+    height: 8.5rem;
 }
 
 {% call utils.large_and_extra_large() %}
@@ -311,6 +325,7 @@ div.cta-block {
 .assessments {
     {{ utils.slate_to_woodsmoke() }}
     color: white;
+    position: relative;
 }
 
 .assessments__header,
@@ -405,3 +420,13 @@ div.cta-block {
         padding: unset;
     }
 {% endcall %}
+
+/* Contact form section */
+#contact-form {
+    position: relative;
+}
+
+#contact-form .cm-form-wrapper {
+    z-index: 1;
+    position: relative;
+}

--- a/version_control/Codurance_September2020/templates/assessment-page.html
+++ b/version_control/Codurance_September2020/templates/assessment-page.html
@@ -18,11 +18,24 @@ label: Assessment Page
 %}
 {% set assessment_color_code = content.widgets.assessment_color.body.color %}
 
+{% image_src "hero_background_image" 
+  label="Choose background image for the hero section" 
+  export_to_template_context=True 
+%}
+
 {% require_css %}
   <style>
     .gradient-container {
       background: transparent linear-gradient(0deg, {{ assessment_color_code }} 0%, #FF585100 100%) 0% 0% no-repeat padding-box;
     }
+
+    {% if widget_data.hero_background_image.src %}
+      .hero {
+        background: url({{ widget_data.hero_background_image.src }});
+        background-position: center;
+        background-size: cover;
+      }
+    {% endif %}
     
     .solution .features-listing__item,
     .benefits .features-listing__item {

--- a/version_control/Codurance_September2020/templates/assessment-page.html
+++ b/version_control/Codurance_September2020/templates/assessment-page.html
@@ -20,6 +20,10 @@ label: Assessment Page
 
 {% require_css %}
   <style>
+    .gradient-container {
+      background: transparent linear-gradient(0deg, {{ assessment_color_code }} 0%, #FF585100 100%) 0% 0% no-repeat padding-box;
+    }
+    
     .solution .features-listing__item,
     .benefits .features-listing__item {
       border-left-color: {{ assessment_color_code }};
@@ -32,6 +36,8 @@ label: Assessment Page
 <main>
   <section class="hero">
     {% module "hero_content" path="../modules/Text-and-image.module" label="Hero section" %}
+
+    <div class="gradient-container"></div>
   </section>
 
   <section class="solution region">
@@ -56,7 +62,10 @@ label: Assessment Page
     {% module "modules_header" path="@hubspot/section_header" label="Modules header" extra_classes="lateral-spacing" %}
     
     <div class="modules__cards-wrapper">
-      <div class="modules__cards-background"></div>
+      <div class="modules__cards-background">
+        <div class="gradient-container"></div>
+      </div>
+
       {% module "module_cards"
         path="../modules/Simple-Card.module"
         label="Modules listing"
@@ -154,11 +163,14 @@ label: Assessment Page
       label="Assessments header" 
       extra_classes="assessments__header lateral-spacing"
     %}
+
     {% module "assessments_listing" 
       path="../modules/How-It-Works.module" 
       label="Assessments listing" 
       extra_classes="assessments__listing"
     %}
+
+    <div class="gradient-container"></div>
   </section>
 
   <section class="related-posts region">
@@ -179,6 +191,8 @@ label: Assessment Page
       label="Contact form"
       path="../modules/Service-Line-Form.module"
     %}
+
+    <div class="gradient-container"></div>
   </section>
 </main>
 

--- a/version_control/Codurance_September2020/templates/assessment-page.html
+++ b/version_control/Codurance_September2020/templates/assessment-page.html
@@ -20,7 +20,8 @@ label: Assessment Page
 
 {% require_css %}
   <style>
-    .solution .features-listing__item {
+    .solution .features-listing__item,
+    .benefits .features-listing__item {
       border-left-color: {{ assessment_color_code }};
     }
   </style>

--- a/version_control/Codurance_September2020/templates/assessment-page.html
+++ b/version_control/Codurance_September2020/templates/assessment-page.html
@@ -12,6 +12,20 @@ label: Assessment Page
 
 {{ require_css(get_asset_url("../css/pages/assessment.css")) }}
 
+{% color "assessment_color" 
+  label="Choose the color for the assessment" 
+  export_to_template_context=True
+%}
+{% set assessment_color_code = content.widgets.assessment_color.body.color %}
+
+{% require_css %}
+  <style>
+    .solution .features-listing__item {
+      border-left-color: {{ assessment_color_code }};
+    }
+  </style>
+{% end_require_css %}
+
 {% block body %}
 
 <main>

--- a/version_control/Codurance_September2020/templates/assessment-page.html
+++ b/version_control/Codurance_September2020/templates/assessment-page.html
@@ -33,6 +33,11 @@ label: Assessment Page
 
 {% block body %}
 
+{% boolean "show_testimonials" label='Show testimonials?' value='True' export_to_template_context=True %}
+{% boolean "show_case_studies" label='Show case studies?' value='True' export_to_template_context=True %}
+{% boolean "show_modules" label='Show modules?' value='True' export_to_template_context=True %}
+{% boolean "show_engagement_models" label='Show engagement models?' value='True' export_to_template_context=True %}
+
 <main>
   <section class="hero">
     {% module "hero_content" path="../modules/Text-and-image.module" label="Hero section" %}
@@ -57,22 +62,24 @@ label: Assessment Page
       {% module "solution_text" path="@hubspot/text" label="Solution text" extra_classes="solution__text" %}			
 		</div>	
   </section>
+  
+  {% if widget_data.show_modules.value %}
+    <section class="modules region">
+      {% module "modules_header" path="@hubspot/section_header" label="Modules header" extra_classes="lateral-spacing" %}
+      
+      <div class="modules__cards-wrapper">
+        <div class="modules__cards-background">
+          <div class="gradient-container"></div>
+        </div>
 
-  <section class="modules region">
-    {% module "modules_header" path="@hubspot/section_header" label="Modules header" extra_classes="lateral-spacing" %}
-    
-    <div class="modules__cards-wrapper">
-      <div class="modules__cards-background">
-        <div class="gradient-container"></div>
+        {% module "module_cards"
+          path="../modules/Simple-Card.module"
+          label="Modules listing"
+          extra_classes="modules__cards"
+        %}
       </div>
-
-      {% module "module_cards"
-        path="../modules/Simple-Card.module"
-        label="Modules listing"
-        extra_classes="modules__cards"
-      %}
-    </div>
-  </section>
+    </section>
+  {% endif %}
 
   <section class="benefits region">
     <div class="benefits__wrapper lateral-spacing">
@@ -96,15 +103,10 @@ label: Assessment Page
     </div>
   </section>
 
-  {% module "testimonials_listing"
-    label="Testimonials"
-    path="../modules/Landing Page Modules/LP-testimonial-slider.module"
-    export_to_template_context=True
-  %}
-
-  {% if widget_data.testimonials_listing.body.testimonial_items %}
+  {% if widget_data.show_testimonials.value %}
     <section class="testimonials">
       {% module "testimonials_listing"
+        label="Testimonials"
         path="../modules/Landing Page Modules/LP-testimonial-slider.module"
       %}
     </section>
@@ -124,36 +126,33 @@ label: Assessment Page
     </div>
   </section>
 
-  {% module "case_studies" 
-    label="Case studies list" 
-    path="../modules/Case Study Card Collection.module"
-    export_to_template_context=True
-  %}
-
-  {% if widget_data.case_studies.body.case_study_card %}
+  {% if widget_data.show_case_studies.value %}
     <section class="case-studies region">
-      {% module "case_studies"  
+      {% module "case_studies" 
+        label="Case studies list" 
         path="../modules/Case Study Card Collection.module"
       %}
     </section>
   {% endif %}
 
-  <section class="models region">
-    {% module "models_header" 
-      path="@hubspot/section_header" 
-      label="Engagement models header" 
-      extra_classes="lateral-spacing" 
-    %}
-    {% module "engagement_models" path="../modules/Engagement-Models.module" %}
-    
-    <div class="models__text-container lateral-spacing">
-      {% module "models_text"
-        path="@hubspot/text"
-        label="Engagement models text"
-        extra_classes="models__text lateral-spacing"
+  {% if widget_data.show_engagement_models.value %}
+    <section class="models region">
+      {% module "models_header" 
+        path="@hubspot/section_header" 
+        label="Engagement models header" 
+        extra_classes="lateral-spacing" 
       %}
-    </div>
-  </section>
+      {% module "engagement_models" path="../modules/Engagement-Models.module" %}
+      
+      <div class="models__text-container lateral-spacing">
+        {% module "models_text"
+          path="@hubspot/text"
+          label="Engagement models text"
+          extra_classes="models__text lateral-spacing"
+        %}
+      </div>
+    </section>
+  {% endif %}
 
   <section>{% module "cta" path="../modules/LP-cta-block.module" label="CTA" %}</section>
 


### PR DESCRIPTION
- Create a more abstract template for the future assessment pages from the existing SQA one
- Set up field to choose a main color that would be shown on several elements on the page, including gradients on several sections and the bullet points on features listings
- Set up field to set up a background for the hero section
- Set up toggles to show/display some optional sections